### PR TITLE
Bump to webpack 5

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 const { join } = require("path");
 
 module.exports = {
+  future: {
+    // https://twitter.com/timneutkens/status/1377950178913714177
+    webpack5: true
+  },
   images: {
     domains: ['pbs.twimg.com'],
   },


### PR DESCRIPTION
https://twitter.com/timneutkens/status/1377950178913714177

> Next.js will soon adopt webpack 5 as the default for compilation. We've spent a lot of effort into ensuring the transition from webpack 4 to 5 will be as smooth as possible. For example Next.js now comes with both webpack 4 and 5 allowing you to adopt webpack 5 by adding a flag to your `next.config.js`.