### PR TITLE
Fix ts-node scripts for TypeScript 6 compatibility

### DIFF
--- a/.github/workflows/update-themes.yml
+++ b/.github/workflows/update-themes.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run theme detection
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: npx ts-node -O '{"module":"commonjs"}' scripts/update-themes.ts
+        run: npx ts-node -O '{"module":"commonjs","types":["node"]}' scripts/update-themes.ts
 
       - name: Check for changes
         id: changes

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "build:feed": "ts-node -O '{\"module\":\"commonjs\"}' -s ./data/gen-rss-feed.ts",
+    "build:feed": "ts-node -O '{\"module\":\"commonjs\",\"types\":[\"node\"]}' -s ./data/gen-rss-feed.ts",
     "build:rss": "npm run build:feed",
-    "build:posts": "ts-node -O '{\"module\":\"commonjs\"}' -s ./data/gen-post-list.ts",
+    "build:posts": "ts-node -O '{\"module\":\"commonjs\",\"types\":[\"node\"]}' -s ./data/gen-post-list.ts",
     "commit:posts": "git add ./data/posts.ts ./public/feed.json",
     "start": "next start",
     "lint": "eslint ./pages/* ./core/* ./data/* --fix",


### PR DESCRIPTION
TypeScript 6.0.2 no longer auto-includes @types/node globals, causing
ts-node compilation to fail with TS2591 for fs, path, and process.
Add "types":["node"] to the compiler options override in all ts-node
invocations (build:feed, build:posts, and the update-themes workflow).

https://claude.ai/code/session_01JXNNnyT9Z5qiy4NZZZvas9