### PR TITLE
Add real-time chess game

### DIFF
--- a/game-server-standalone.js
+++ b/game-server-standalone.js
@@ -4,10 +4,13 @@
 const { createServer } = require('http');
 const { Server } = require('socket.io');
 const { createGame, joinGame, startGame, placeCard, revealThing } = require('./lib/game-server.js');
+const chessServer = require('./lib/chess-server.js');
 
 // Game state storage
 const games = new Map();
 const playerGames = new Map();
+const chessGames = new Map();
+const chessPlayerGames = new Map();
 
 const server = createServer((req, res) => {
   // Simple health check endpoint
@@ -187,8 +190,102 @@ setInterval(() => {
   }
 }, 5 * 60 * 1000);
 
+// --- Chess namespace ---
+const chessNamespace = io.of('/chess');
+
+chessNamespace.on('connection', (socket) => {
+  console.log(`Chess player connected: ${socket.id}`);
+
+  socket.on('createGame', (data) => {
+    try {
+      const result = chessServer.createGame(data.playerName, socket.id);
+      chessGames.set(result.gameCode, result.game);
+      chessPlayerGames.set(socket.id, result.gameCode);
+      socket.join(result.gameCode);
+      socket.emit('gameCreated', { gameId: result.gameCode, playerId: socket.id });
+      socket.emit('gameStateUpdate', result.game);
+    } catch (e) { socket.emit('error', { message: e.message }); }
+  });
+
+  socket.on('joinGame', (data) => {
+    try {
+      const gameCode = data.gameCode.toUpperCase();
+      const game = chessGames.get(gameCode);
+      if (!game) throw new Error('Game not found');
+      const result = chessServer.joinGame(game, data.playerName, socket.id);
+      chessPlayerGames.set(socket.id, gameCode);
+      socket.join(gameCode);
+      socket.emit('gameJoined', { gameId: gameCode, playerId: socket.id });
+      chessNamespace.to(gameCode).emit('gameStateUpdate', result.game);
+    } catch (e) { socket.emit('error', { message: e.message }); }
+  });
+
+  socket.on('startGame', (data) => {
+    try {
+      const game = chessGames.get(data.gameCode);
+      if (!game) throw new Error('Game not found');
+      const result = chessServer.startGame(game, socket.id);
+      chessNamespace.to(data.gameCode).emit('gameStateUpdate', result.game);
+    } catch (e) { socket.emit('error', { message: e.message }); }
+  });
+
+  socket.on('movePiece', (data) => {
+    try {
+      const game = chessGames.get(data.gameCode);
+      if (!game) throw new Error('Game not found');
+      const result = chessServer.moveChessPiece(game, socket.id, data.from, data.to);
+      chessNamespace.to(data.gameCode).emit('gameStateUpdate', result.game);
+    } catch (e) { socket.emit('error', { message: e.message }); }
+  });
+
+  socket.on('playAgain', (data) => {
+    try {
+      const game = chessGames.get(data.gameCode);
+      if (!game) throw new Error('Game not found');
+      const result = chessServer.playAgain(game, socket.id);
+      chessNamespace.to(data.gameCode).emit('gameStateUpdate', result.game);
+    } catch (e) { socket.emit('error', { message: e.message }); }
+  });
+
+  socket.on('disconnect', () => {
+    const gameCode = chessPlayerGames.get(socket.id);
+    if (gameCode) {
+      const game = chessGames.get(gameCode);
+      if (game) {
+        const player = game.players.find(p => p.id === socket.id);
+        if (player) { player.connected = false; player.lastSeen = Date.now(); }
+        chessNamespace.to(gameCode).emit('gameStateUpdate', game);
+      }
+      chessPlayerGames.delete(socket.id);
+    }
+  });
+
+  socket.on('heartbeat', () => {
+    const gameCode = chessPlayerGames.get(socket.id);
+    if (gameCode) {
+      const game = chessGames.get(gameCode);
+      if (game) {
+        const player = game.players.find(p => p.id === socket.id);
+        if (player) { player.connected = true; player.lastSeen = Date.now(); }
+      }
+    }
+  });
+});
+
+setInterval(() => {
+  const now = Date.now();
+  const maxAge = 2 * 60 * 60 * 1000;
+  for (const [code, game] of chessGames.entries()) {
+    if (now - game.lastActivity > maxAge) {
+      for (const p of game.players) chessPlayerGames.delete(p.id);
+      chessGames.delete(code);
+    }
+  }
+}, 5 * 60 * 1000);
+
 const port = process.env.PORT || 3001;
 server.listen(port, () => {
   console.log(`> Game Server ready on port ${port}`);
   console.log(`> Socket.IO ready at ws://localhost:${port}/who-goes-there`);
+  console.log(`> Chess Socket.IO ready at ws://localhost:${port}/chess`);
 });

--- a/lib/chess-server.js
+++ b/lib/chess-server.js
@@ -1,0 +1,233 @@
+const COOLDOWN_MS = 1500;
+
+function generateGameCode() {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let result = '';
+  for (let i = 0; i < 6; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}
+
+function fileIndex(file) { return file.charCodeAt(0) - 97; } // 'a'=0
+function rankIndex(rank) { return rank - 1; }
+function toPos(f, r) { return `${String.fromCharCode(97 + f)}${r + 1}`; }
+function fromPos(pos) { return { f: fileIndex(pos[0]), r: parseInt(pos[1]) - 1 }; }
+
+function initialBoard() {
+  const board = {};
+  const backRank = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook'];
+  for (let f = 0; f < 8; f++) {
+    board[toPos(f, 0)] = { type: backRank[f], color: 'white' };
+    board[toPos(f, 1)] = { type: 'pawn', color: 'white' };
+    board[toPos(f, 6)] = { type: 'pawn', color: 'black' };
+    board[toPos(f, 7)] = { type: backRank[f], color: 'black' };
+  }
+  return board;
+}
+
+function getLegalMoves(board, from, color) {
+  const piece = board[from];
+  if (!piece || piece.color !== color) return [];
+
+  const { f, r } = fromPos(from);
+  const moves = [];
+
+  const slide = (df, dr) => {
+    let tf = f + df, tr = r + dr;
+    while (tf >= 0 && tf <= 7 && tr >= 0 && tr <= 7) {
+      const dest = toPos(tf, tr);
+      const dp = board[dest];
+      if (dp) {
+        if (dp.color !== color) moves.push(dest);
+        break;
+      }
+      moves.push(dest);
+      tf += df; tr += dr;
+    }
+  };
+
+  const step = (df, dr) => {
+    const tf = f + df, tr = r + dr;
+    if (tf < 0 || tf > 7 || tr < 0 || tr > 7) return;
+    const dest = toPos(tf, tr);
+    if (!board[dest] || board[dest].color !== color) moves.push(dest);
+  };
+
+  switch (piece.type) {
+    case 'pawn': {
+      const dir = color === 'white' ? 1 : -1;
+      const startR = color === 'white' ? 1 : 6;
+      const fwd = toPos(f, r + dir);
+      if (r + dir >= 0 && r + dir <= 7 && !board[fwd]) {
+        moves.push(fwd);
+        if (r === startR) {
+          const fwd2 = toPos(f, r + dir * 2);
+          if (!board[fwd2]) moves.push(fwd2);
+        }
+      }
+      for (const df of [-1, 1]) {
+        const tf = f + df, tr = r + dir;
+        if (tf >= 0 && tf <= 7 && tr >= 0 && tr <= 7) {
+          const cap = toPos(tf, tr);
+          if (board[cap] && board[cap].color !== color) moves.push(cap);
+        }
+      }
+      break;
+    }
+    case 'knight':
+      for (const [df, dr] of [[-2,-1],[-2,1],[-1,-2],[-1,2],[1,-2],[1,2],[2,-1],[2,1]])
+        step(df, dr);
+      break;
+    case 'bishop':
+      for (const [df, dr] of [[-1,-1],[-1,1],[1,-1],[1,1]]) slide(df, dr);
+      break;
+    case 'rook':
+      for (const [df, dr] of [[0,1],[0,-1],[1,0],[-1,0]]) slide(df, dr);
+      break;
+    case 'queen':
+      for (const [df, dr] of [[0,1],[0,-1],[1,0],[-1,0],[-1,-1],[-1,1],[1,-1],[1,1]])
+        slide(df, dr);
+      break;
+    case 'king':
+      for (const [df, dr] of [[0,1],[0,-1],[1,0],[-1,0],[-1,-1],[-1,1],[1,-1],[1,1]])
+        step(df, dr);
+      break;
+  }
+
+  return moves;
+}
+
+function isInCheck(board, color) {
+  let kingPos = null;
+  for (const [pos, piece] of Object.entries(board)) {
+    if (piece.type === 'king' && piece.color === color) { kingPos = pos; break; }
+  }
+  if (!kingPos) return false;
+  const opp = color === 'white' ? 'black' : 'white';
+  for (const pos of Object.keys(board)) {
+    if (board[pos].color === opp) {
+      if (getLegalMoves(board, pos, opp).includes(kingPos)) return true;
+    }
+  }
+  return false;
+}
+
+function createGame(playerName, playerId) {
+  if (!playerName || !playerName.trim()) throw new Error('Player name required');
+  const gameCode = generateGameCode();
+  const game = {
+    id: gameCode,
+    players: [{ id: playerId, name: playerName.trim(), color: 'white', connected: true, lastSeen: Date.now() }],
+    board: {},
+    cooldowns: {},
+    inCheck: { white: false, black: false },
+    gameStarted: false,
+    gameEnded: false,
+    winner: null,
+    winnerName: null,
+    status: 'waiting',
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+  };
+  return { gameCode, game };
+}
+
+function joinGame(game, playerName, playerId) {
+  if (!playerName || !playerName.trim()) throw new Error('Player name required');
+  if (game.gameStarted) throw new Error('Game already started');
+  if (game.players.length >= 2) throw new Error('Game is full');
+  if (game.players.some(p => p.name.toLowerCase() === playerName.trim().toLowerCase()))
+    throw new Error('Name already taken');
+
+  game.players.push({ id: playerId, name: playerName.trim(), color: 'black', connected: true, lastSeen: Date.now() });
+  game.lastActivity = Date.now();
+  return { game };
+}
+
+function startGame(game, playerId) {
+  if (!game.players.some(p => p.id === playerId)) throw new Error('Not in this game');
+  if (game.players.length < 2) throw new Error('Need 2 players to start');
+  if (game.gameStarted) throw new Error('Game already started');
+
+  game.board = initialBoard();
+  game.cooldowns = {};
+  game.inCheck = { white: false, black: false };
+  game.gameStarted = true;
+  game.gameEnded = false;
+  game.winner = null;
+  game.winnerName = null;
+  game.status = 'playing';
+  game.lastActivity = Date.now();
+  return { game };
+}
+
+function moveChessPiece(game, playerId, from, to) {
+  if (!game.gameStarted || game.gameEnded) throw new Error('Game not in progress');
+
+  const player = game.players.find(p => p.id === playerId);
+  if (!player) throw new Error('Not in this game');
+
+  const piece = game.board[from];
+  if (!piece) throw new Error('No piece at source');
+  if (piece.color !== player.color) throw new Error('Not your piece');
+
+  const now = Date.now();
+  if (game.cooldowns[from] && game.cooldowns[from] > now) throw new Error('Piece is on cooldown');
+
+  const legal = getLegalMoves(game.board, from, player.color);
+  if (!legal.includes(to)) throw new Error('Illegal move');
+
+  const captured = game.board[to];
+  const kingCaptured = captured && captured.type === 'king';
+
+  game.board[to] = { ...piece };
+  delete game.board[from];
+  delete game.cooldowns[from];
+  game.cooldowns[to] = now + COOLDOWN_MS;
+
+  // Pawn promotion → queen
+  if (piece.type === 'pawn') {
+    const { r } = fromPos(to);
+    if ((player.color === 'white' && r === 7) || (player.color === 'black' && r === 0)) {
+      game.board[to].type = 'queen';
+    }
+  }
+
+  game.inCheck = {
+    white: isInCheck(game.board, 'white'),
+    black: isInCheck(game.board, 'black'),
+  };
+
+  game.lastActivity = now;
+
+  if (kingCaptured) {
+    game.gameEnded = true;
+    game.winner = playerId;
+    game.winnerName = player.name;
+    game.status = 'ended';
+  }
+
+  return { game };
+}
+
+function playAgain(game, playerId) {
+  if (!game.players.some(p => p.id === playerId)) throw new Error('Not in this game');
+  if (!game.gameEnded) throw new Error('Game is not over');
+
+  // Swap colors
+  game.players.forEach(p => { p.color = p.color === 'white' ? 'black' : 'white'; });
+
+  game.board = initialBoard();
+  game.cooldowns = {};
+  game.inCheck = { white: false, black: false };
+  game.gameStarted = true;
+  game.gameEnded = false;
+  game.winner = null;
+  game.winnerName = null;
+  game.status = 'playing';
+  game.lastActivity = Date.now();
+  return { game };
+}
+
+module.exports = { createGame, joinGame, startGame, moveChessPiece, playAgain, getLegalMoves };

--- a/pages/chess.module.css
+++ b/pages/chess.module.css
@@ -1,0 +1,337 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+.title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 4px;
+}
+
+.subtitle {
+  font-size: 0.875rem;
+  opacity: 0.6;
+  margin: 0 0 24px;
+}
+
+/* ── Lobby ── */
+.lobby {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  max-width: 320px;
+}
+
+.lobbyButtons {
+  display: flex;
+  gap: 8px;
+}
+
+.input {
+  padding: 10px 14px;
+  font-size: 1rem;
+  border: 2px solid #ccc;
+  border-radius: 8px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #555;
+}
+
+.btn {
+  padding: 10px 20px;
+  font-size: 1rem;
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  flex: 1;
+  transition: opacity 0.15s;
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.btnPrimary {
+  background: #1a1a1a;
+  color: #fff;
+}
+
+.btnPrimary:hover:not(:disabled) {
+  background: #333;
+}
+
+.btnSecondary {
+  background: #e8e8e8;
+  color: #1a1a1a;
+}
+
+.btnSecondary:hover:not(:disabled) {
+  background: #d0d0d0;
+}
+
+.btnDanger {
+  background: #c0392b;
+  color: #fff;
+}
+
+.btnDanger:hover:not(:disabled) {
+  background: #a93226;
+}
+
+/* ── Waiting room ── */
+.waiting {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  max-width: 320px;
+  width: 100%;
+  text-align: center;
+}
+
+.gameCode {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  font-family: monospace;
+  background: #f0f0f0;
+  padding: 8px 20px;
+  border-radius: 8px;
+}
+
+.playerList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.playerList li {
+  padding: 8px 12px;
+  background: #f5f5f5;
+  border-radius: 6px;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.colorDot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid #888;
+  flex-shrink: 0;
+}
+
+.colorDotWhite { background: #fff; }
+.colorDotBlack { background: #1a1a1a; }
+
+/* ── Board ── */
+.gameLayout {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+}
+
+.playerInfo {
+  display: flex;
+  justify-content: space-between;
+  width: min(480px, 100vw - 32px);
+  font-size: 0.875rem;
+}
+
+.playerTag {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 20px;
+  background: #f0f0f0;
+  font-weight: 600;
+}
+
+.playerTag.isYou {
+  background: #1a1a1a;
+  color: #fff;
+}
+
+.inCheck {
+  background: #e74c3c !important;
+  color: #fff !important;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  width: min(480px, 100vw - 32px);
+  height: min(480px, 100vw - 32px);
+  border: 3px solid #1a1a1a;
+  border-radius: 4px;
+  overflow: hidden;
+  user-select: none;
+}
+
+.square {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  aspect-ratio: 1;
+}
+
+.light { background: #f0d9b5; }
+.dark  { background: #b58863; }
+
+.square.selected {
+  background: #f6f669 !important;
+}
+
+.square.legalMove::after {
+  content: '';
+  position: absolute;
+  width: 30%;
+  height: 30%;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.2);
+  pointer-events: none;
+}
+
+.square.legalCapture::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 4px solid rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+}
+
+.square.lastMove {
+  background: rgba(155, 199, 0, 0.4) !important;
+}
+
+.piece {
+  font-size: clamp(28px, 6vw, 48px);
+  line-height: 1;
+  position: relative;
+  z-index: 1;
+  transition: opacity 0.15s;
+}
+
+.whitePiece {
+  color: #fff;
+  text-shadow: 0 0 2px #000, 0 0 4px #000;
+  filter: drop-shadow(0 1px 2px rgba(0,0,0,0.6));
+}
+
+.blackPiece {
+  color: #1a1a1a;
+  text-shadow: 0 0 1px rgba(255,255,255,0.3);
+  filter: drop-shadow(0 1px 1px rgba(0,0,0,0.4));
+}
+
+.cooldownPiece {
+  opacity: 0.4;
+}
+
+.cooldownOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 2px;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.cooldownBadge {
+  font-size: clamp(8px, 1.5vw, 11px);
+  font-weight: 700;
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  border-radius: 3px;
+  padding: 1px 3px;
+  line-height: 1.2;
+}
+
+.cooldownBar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: #e74c3c;
+  pointer-events: none;
+  z-index: 3;
+  transition: width 0.1s linear;
+}
+
+/* ── Rank / file labels ── */
+.rankLabel {
+  position: absolute;
+  top: 2px;
+  left: 3px;
+  font-size: clamp(8px, 1.5vw, 11px);
+  font-weight: 700;
+  opacity: 0.5;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.fileLabel {
+  position: absolute;
+  bottom: 2px;
+  right: 3px;
+  font-size: clamp(8px, 1.5vw, 11px);
+  font-weight: 700;
+  opacity: 0.5;
+  line-height: 1;
+  pointer-events: none;
+}
+
+/* ── Status / end ── */
+.status {
+  font-size: 0.875rem;
+  opacity: 0.7;
+}
+
+.endScreen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+  padding: 24px;
+  max-width: 320px;
+}
+
+.endTitle {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.endSubtitle {
+  opacity: 0.7;
+}
+
+.error {
+  color: #e74c3c;
+  font-size: 0.875rem;
+  text-align: center;
+  margin: 0;
+}

--- a/pages/chess.tsx
+++ b/pages/chess.tsx
@@ -1,0 +1,482 @@
+import Head from "@core/head";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { io, Socket } from "socket.io-client";
+import styles from "./chess.module.css";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+type PieceType = "king" | "queen" | "rook" | "bishop" | "knight" | "pawn";
+type Color = "white" | "black";
+
+interface Piece {
+  type: PieceType;
+  color: Color;
+}
+
+interface Player {
+  id: string;
+  name: string;
+  color: Color;
+  connected: boolean;
+}
+
+interface ChessGame {
+  id: string;
+  players: Player[];
+  board: Record<string, Piece>;
+  cooldowns: Record<string, number>;
+  inCheck: { white: boolean; black: boolean };
+  gameStarted: boolean;
+  gameEnded: boolean;
+  winner: string | null;
+  winnerName: string | null;
+  status: "waiting" | "playing" | "ended";
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const PIECE_GLYPHS: Record<Color, Record<PieceType, string>> = {
+  white: { king: "♔", queen: "♕", rook: "♖", bishop: "♗", knight: "♘", pawn: "♙" },
+  black: { king: "♚", queen: "♛", rook: "♜", bishop: "♝", knight: "♞", pawn: "♟" },
+};
+
+const FILES = ["a", "b", "c", "d", "e", "f", "g", "h"];
+const RANKS = [1, 2, 3, 4, 5, 6, 7, 8];
+const COOLDOWN_MS = 1500;
+
+// ── Move calculation (mirrors chess-server.js) ────────────────────────────
+
+function fileIdx(f: string) { return f.charCodeAt(0) - 97; }
+function toPos(f: number, r: number) { return `${String.fromCharCode(97 + f)}${r + 1}`; }
+function fromPos(pos: string) { return { f: fileIdx(pos[0]), r: parseInt(pos[1]) - 1 }; }
+
+function getLegalMoves(board: Record<string, Piece>, from: string, color: Color): string[] {
+  const piece = board[from];
+  if (!piece || piece.color !== color) return [];
+
+  const { f, r } = fromPos(from);
+  const moves: string[] = [];
+
+  const slide = (df: number, dr: number) => {
+    let tf = f + df, tr = r + dr;
+    while (tf >= 0 && tf <= 7 && tr >= 0 && tr <= 7) {
+      const dest = toPos(tf, tr);
+      const dp = board[dest];
+      if (dp) { if (dp.color !== color) moves.push(dest); break; }
+      moves.push(dest);
+      tf += df; tr += dr;
+    }
+  };
+
+  const step = (df: number, dr: number) => {
+    const tf = f + df, tr = r + dr;
+    if (tf < 0 || tf > 7 || tr < 0 || tr > 7) return;
+    const dest = toPos(tf, tr);
+    if (!board[dest] || board[dest].color !== color) moves.push(dest);
+  };
+
+  switch (piece.type) {
+    case "pawn": {
+      const dir = color === "white" ? 1 : -1;
+      const startR = color === "white" ? 1 : 6;
+      const fwd = toPos(f, r + dir);
+      if (r + dir >= 0 && r + dir <= 7 && !board[fwd]) {
+        moves.push(fwd);
+        if (r === startR) { const fwd2 = toPos(f, r + dir * 2); if (!board[fwd2]) moves.push(fwd2); }
+      }
+      for (const df of [-1, 1]) {
+        const tf = f + df, tr = r + dir;
+        if (tf >= 0 && tf <= 7 && tr >= 0 && tr <= 7) {
+          const cap = toPos(tf, tr);
+          if (board[cap] && board[cap].color !== color) moves.push(cap);
+        }
+      }
+      break;
+    }
+    case "knight":
+      for (const [df, dr] of [[-2,-1],[-2,1],[-1,-2],[-1,2],[1,-2],[1,2],[2,-1],[2,1]])
+        step(df, dr);
+      break;
+    case "bishop": for (const [df, dr] of [[-1,-1],[-1,1],[1,-1],[1,1]]) slide(df, dr); break;
+    case "rook":   for (const [df, dr] of [[0,1],[0,-1],[1,0],[-1,0]]) slide(df, dr); break;
+    case "queen":
+      for (const [df, dr] of [[0,1],[0,-1],[1,0],[-1,0],[-1,-1],[-1,1],[1,-1],[1,1]])
+        slide(df, dr);
+      break;
+    case "king":
+      for (const [df, dr] of [[0,1],[0,-1],[1,0],[-1,0],[-1,-1],[-1,1],[1,-1],[1,1]])
+        step(df, dr);
+      break;
+  }
+
+  return moves;
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export default function Chess(): React.ReactNode {
+  const [socket, setSocket] = useState<Socket | null>(null);
+  const [gameState, setGameState] = useState<ChessGame | null>(null);
+  const [playerName, setPlayerName] = useState("");
+  const [gameCode, setGameCode] = useState("");
+  const [inputCode, setInputCode] = useState("");
+  const [playerId, setPlayerId] = useState("");
+  const [myColor, setMyColor] = useState<Color | null>(null);
+  const [selectedSquare, setSelectedSquare] = useState<string | null>(null);
+  const [legalMoves, setLegalMoves] = useState<string[]>([]);
+  const [joinMode, setJoinMode] = useState<"create" | "join" | null>(null);
+  const [errorMsg, setErrorMsg] = useState("");
+  const [connectionError, setConnectionError] = useState(false);
+  const [now, setNow] = useState(Date.now());
+
+  // Keep stable ref to myColor to avoid stale closure in socket callback
+  const myColorRef = useRef(myColor);
+  myColorRef.current = myColor;
+
+  // Tick for cooldown countdowns
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 100);
+    return () => clearInterval(id);
+  }, []);
+
+  // Socket setup
+  useEffect(() => {
+    const url = process.env.NEXT_PUBLIC_GAME_SERVER_URL || "";
+    const newSocket = io(`${url}/chess`, {
+      ...(url ? {} : { path: "/api/socketio" }),
+      transports: ["websocket", "polling"],
+    });
+
+    setSocket(newSocket);
+
+    newSocket.on("connect", () => setConnectionError(false));
+    newSocket.on("connect_error", () => setConnectionError(true));
+
+    newSocket.on("gameCreated", ({ gameId, playerId: pid }: { gameId: string; playerId: string }) => {
+      setGameCode(gameId);
+      setPlayerId(pid);
+      setMyColor("white");
+      myColorRef.current = "white";
+    });
+
+    newSocket.on("gameJoined", ({ gameId, playerId: pid }: { gameId: string; playerId: string }) => {
+      setGameCode(gameId);
+      setPlayerId(pid);
+    });
+
+    newSocket.on("gameStateUpdate", (state: ChessGame) => {
+      setGameState(state);
+      // Resolve our color from the updated player list
+      const pid = newSocket.id;
+      const me = state.players.find((p) => p.id === pid);
+      if (me) {
+        setMyColor(me.color);
+        myColorRef.current = me.color;
+      }
+      // Clear selection when game ends
+      if (state.gameEnded) { setSelectedSquare(null); setLegalMoves([]); }
+    });
+
+    newSocket.on("error", ({ message }: { message: string }) => {
+      setErrorMsg(message);
+      setTimeout(() => setErrorMsg(""), 3000);
+    });
+
+    const hb = setInterval(() => newSocket.emit("heartbeat"), 5000);
+
+    return () => {
+      clearInterval(hb);
+      newSocket.disconnect();
+    };
+  }, []);
+
+  // ── Actions ──
+
+  const handleCreate = () => {
+    if (!socket || !playerName.trim()) return;
+    socket.emit("createGame", { playerName: playerName.trim() });
+    setJoinMode("create");
+  };
+
+  const handleJoin = () => {
+    if (!socket || !playerName.trim() || !inputCode.trim()) return;
+    socket.emit("joinGame", { playerName: playerName.trim(), gameCode: inputCode.trim() });
+    setJoinMode("join");
+  };
+
+  const handleStart = () => {
+    if (!socket || !gameCode) return;
+    socket.emit("startGame", { gameCode });
+  };
+
+  const handlePlayAgain = () => {
+    if (!socket || !gameCode) return;
+    socket.emit("playAgain", { gameCode });
+    setSelectedSquare(null);
+    setLegalMoves([]);
+  };
+
+  // ── Board interaction ──
+
+  const selectSquare = useCallback((sq: string) => {
+    if (!gameState) return;
+    const color = myColorRef.current;
+    if (!color) return;
+    const coolUntil = gameState.cooldowns?.[sq] ?? 0;
+    if (coolUntil > Date.now()) return; // on cooldown
+    const moves = getLegalMoves(gameState.board, sq, color);
+    setSelectedSquare(sq);
+    setLegalMoves(moves);
+  }, [gameState]);
+
+  const handleSquareClick = useCallback((sq: string) => {
+    if (!gameState?.gameStarted || gameState.gameEnded || !myColor || !socket || !gameCode) return;
+    const piece = gameState.board[sq];
+
+    if (selectedSquare) {
+      if (legalMoves.includes(sq)) {
+        socket.emit("movePiece", { gameCode, from: selectedSquare, to: sq });
+        setSelectedSquare(null);
+        setLegalMoves([]);
+      } else if (piece && piece.color === myColor) {
+        selectSquare(sq);
+      } else {
+        setSelectedSquare(null);
+        setLegalMoves([]);
+      }
+    } else {
+      if (piece && piece.color === myColor) selectSquare(sq);
+    }
+  }, [gameState, myColor, socket, gameCode, selectedSquare, legalMoves, selectSquare]);
+
+  // ── Render helpers ──
+
+  const renderBoard = () => {
+    if (!gameState?.board) return null;
+
+    // White: rank 8 at top → ranks 8..1, files a..h
+    // Black: rank 1 at top → ranks 1..8, files h..a (flipped)
+    const rankOrder = myColor === "black" ? [1,2,3,4,5,6,7,8] : [8,7,6,5,4,3,2,1];
+    const fileOrder = myColor === "black" ? ["h","g","f","e","d","c","b","a"] : FILES;
+
+    return rankOrder.flatMap((rank, ri) =>
+      fileOrder.map((file, fi) => {
+        const sq = `${file}${rank}`;
+        const piece = gameState.board[sq];
+        const isLight = (fileIdx(file) + rank) % 2 === 1;
+        const isSelected = selectedSquare === sq;
+        const isLegal = legalMoves.includes(sq);
+        const isCapture = isLegal && !!piece;
+        const coolUntil = gameState.cooldowns?.[sq] ?? 0;
+        const onCooldown = coolUntil > now;
+        const coolFrac = onCooldown ? Math.max(0, (coolUntil - now) / COOLDOWN_MS) : 0;
+
+        const showRankLabel = fi === 0;
+        const showFileLabel = ri === 7;
+
+        return (
+          <div
+            key={sq}
+            className={[
+              styles.square,
+              isLight ? styles.light : styles.dark,
+              isSelected ? styles.selected : "",
+              isLegal && !isCapture ? styles.legalMove : "",
+              isCapture ? styles.legalCapture : "",
+            ].filter(Boolean).join(" ")}
+            onClick={() => handleSquareClick(sq)}
+          >
+            {showRankLabel && (
+              <span className={styles.rankLabel}>{rank}</span>
+            )}
+            {showFileLabel && (
+              <span className={styles.fileLabel}>{file}</span>
+            )}
+            {piece && (
+              <span className={[
+                styles.piece,
+                piece.color === "white" ? styles.whitePiece : styles.blackPiece,
+                onCooldown ? styles.cooldownPiece : "",
+              ].filter(Boolean).join(" ")}>
+                {PIECE_GLYPHS[piece.color][piece.type]}
+              </span>
+            )}
+            {onCooldown && (
+              <>
+                <div className={styles.cooldownBar} style={{ width: `${coolFrac * 100}%` }} />
+                <div className={styles.cooldownOverlay}>
+                  <span className={styles.cooldownBadge}>
+                    {((coolUntil - now) / 1000).toFixed(1)}s
+                  </span>
+                </div>
+              </>
+            )}
+          </div>
+        );
+      })
+    );
+  };
+
+  // ── Render phases ──
+
+  if (connectionError) {
+    return (
+      <div className={styles.page}>
+        <h1 className={styles.title}>Chess</h1>
+        <p className={styles.error}>Could not connect to game server.</p>
+      </div>
+    );
+  }
+
+  // Lobby
+  if (!gameCode) {
+    return (
+      <div className={styles.page}>
+        <Head title="Chess" />
+        <h1 className={styles.title}>Chess</h1>
+        <p className={styles.subtitle}>Real-time · no turns · move as fast as you can</p>
+        <div className={styles.lobby}>
+          <input
+            className={styles.input}
+            placeholder="Your name"
+            value={playerName}
+            onChange={(e) => setPlayerName(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+            maxLength={20}
+          />
+          {joinMode === "join" && (
+            <input
+              className={styles.input}
+              placeholder="Game code"
+              value={inputCode}
+              onChange={(e) => setInputCode(e.target.value.toUpperCase())}
+              maxLength={6}
+              autoFocus
+            />
+          )}
+          <div className={styles.lobbyButtons}>
+            <button
+              className={`${styles.btn} ${styles.btnPrimary}`}
+              onClick={handleCreate}
+              disabled={!playerName.trim() || joinMode === "join"}
+            >
+              New game
+            </button>
+            {joinMode === "join" ? (
+              <button
+                className={`${styles.btn} ${styles.btnPrimary}`}
+                onClick={handleJoin}
+                disabled={!playerName.trim() || !inputCode.trim()}
+              >
+                Join
+              </button>
+            ) : (
+              <button
+                className={`${styles.btn} ${styles.btnSecondary}`}
+                onClick={() => setJoinMode("join")}
+                disabled={!playerName.trim()}
+              >
+                Join game
+              </button>
+            )}
+          </div>
+          {errorMsg && <p className={styles.error}>{errorMsg}</p>}
+        </div>
+      </div>
+    );
+  }
+
+  // Waiting room
+  if (!gameState?.gameStarted) {
+    const canStart = (gameState?.players.length ?? 0) >= 2 && gameState?.players.some(p => p.id === playerId);
+    return (
+      <div className={styles.page}>
+        <Head title="Chess" />
+        <h1 className={styles.title}>Chess</h1>
+        <div className={styles.waiting}>
+          <p>Share this code with your opponent:</p>
+          <div className={styles.gameCode}>{gameCode}</div>
+          <ul className={styles.playerList}>
+            {gameState?.players.map((p) => (
+              <li key={p.id}>
+                <span className={`${styles.colorDot} ${p.color === "white" ? styles.colorDotWhite : styles.colorDotBlack}`} />
+                {p.name} {p.id === playerId && "(you)"}
+              </li>
+            ))}
+            {(gameState?.players.length ?? 0) < 2 && (
+              <li style={{ opacity: 0.5 }}>Waiting for opponent…</li>
+            )}
+          </ul>
+          <button
+            className={`${styles.btn} ${styles.btnPrimary}`}
+            onClick={handleStart}
+            disabled={!canStart}
+            style={{ width: "100%" }}
+          >
+            Start game
+          </button>
+          {errorMsg && <p className={styles.error}>{errorMsg}</p>}
+        </div>
+      </div>
+    );
+  }
+
+  // End screen
+  if (gameState.gameEnded) {
+    const iWon = gameState.winner === playerId;
+    return (
+      <div className={styles.page}>
+        <Head title="Chess" />
+        <h1 className={styles.title}>Chess</h1>
+        <div className={styles.endScreen}>
+          <div className={styles.endTitle}>{iWon ? "You win! 🏆" : `${gameState.winnerName} wins`}</div>
+          <p className={styles.endSubtitle}>{iWon ? "You captured the king." : "The king was captured."}</p>
+          <div className={styles.board} style={{ marginBottom: 0 }}>
+            {renderBoard()}
+          </div>
+          <button
+            className={`${styles.btn} ${styles.btnPrimary}`}
+            onClick={handlePlayAgain}
+            style={{ width: "100%" }}
+          >
+            Play again (colors swap)
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Active game
+  const me = gameState.players.find((p) => p.id === playerId);
+  const opponent = gameState.players.find((p) => p.id !== playerId);
+  const myInCheck = myColor ? gameState.inCheck[myColor] : false;
+  const oppInCheck = myColor ? gameState.inCheck[myColor === "white" ? "black" : "white"] : false;
+
+  return (
+    <div className={styles.page}>
+      <Head title="Chess" />
+      <div className={styles.gameLayout}>
+        <div className={styles.playerInfo}>
+          {opponent && (
+            <div className={`${styles.playerTag} ${oppInCheck ? styles.inCheck : ""}`}>
+              <span>{PIECE_GLYPHS[opponent.color].king}</span>
+              {opponent.name}
+              {oppInCheck && " — check!"}
+            </div>
+          )}
+          {me && (
+            <div className={`${styles.playerTag} ${styles.isYou} ${myInCheck ? styles.inCheck : ""}`}>
+              <span>{PIECE_GLYPHS[me.color].king}</span>
+              {me.name} (you)
+              {myInCheck && " — check!"}
+            </div>
+          )}
+        </div>
+
+        <div className={styles.board}>{renderBoard()}</div>
+
+        {errorMsg && <p className={styles.error}>{errorMsg}</p>}
+      </div>
+    </div>
+  );
+}

--- a/server.js
+++ b/server.js
@@ -10,9 +10,12 @@ const handle = app.getRequestHandler();
 // Game state storage
 const games = new Map();
 const playerGames = new Map();
+const chessGames = new Map();
+const chessPlayerGames = new Map();
 
 // Game logic imports
 const { createGame, joinGame, startGame, placeCard, revealThing, playAgain } = require('./lib/game-server.js');
+const chessServer = require('./lib/chess-server.js');
 
 app.prepare().then(() => {
   const server = createServer((req, res) => {
@@ -40,11 +43,11 @@ app.prepare().then(() => {
         const result = createGame(data.playerName, socket.id);
         games.set(result.gameCode, result.game);
         playerGames.set(socket.id, result.gameCode);
-        
+
         socket.join(result.gameCode);
         socket.emit('gameCreated', { gameId: result.gameCode, playerId: socket.id });
         socket.emit('gameStateUpdate', result.game);
-        
+
         console.log(`Game created: ${result.gameCode} by ${data.playerName}`);
       } catch (error) {
         socket.emit('error', { message: error.message });
@@ -55,20 +58,20 @@ app.prepare().then(() => {
       try {
         const gameCode = data.gameCode.toUpperCase();
         const game = games.get(gameCode);
-        
+
         if (!game) {
           throw new Error('Game not found');
         }
 
         const result = joinGame(game, data.playerName, socket.id);
         playerGames.set(socket.id, gameCode);
-        
+
         socket.join(gameCode);
         socket.emit('gameJoined', { gameId: gameCode, playerId: socket.id });
-        
+
         // Update all players in the game
         gameNamespace.to(gameCode).emit('gameStateUpdate', result.game);
-        
+
         console.log(`Player ${data.playerName} joined game ${gameCode}`);
       } catch (error) {
         socket.emit('error', { message: error.message });
@@ -98,14 +101,14 @@ app.prepare().then(() => {
       try {
         const gameCode = data.gameCode;
         const game = games.get(gameCode);
-        
+
         if (!game) {
           throw new Error('Game not found');
         }
 
         const result = placeCard(game, socket.id, data.cardIndex, data.position);
         gameNamespace.to(gameCode).emit('gameStateUpdate', result.game);
-        
+
         console.log(`Card placed in game ${gameCode} at ${data.position}`);
       } catch (error) {
         socket.emit('error', { message: error.message });
@@ -150,7 +153,7 @@ app.prepare().then(() => {
 
     socket.on('disconnect', () => {
       console.log(`Player disconnected: ${socket.id}`);
-      
+
       const gameCode = playerGames.get(socket.id);
       if (gameCode) {
         const game = games.get(gameCode);
@@ -159,7 +162,7 @@ app.prepare().then(() => {
           if (player) {
             player.connected = false;
             player.lastSeen = Date.now();
-            
+
             // Notify other players
             gameNamespace.to(gameCode).emit('gameStateUpdate', game);
           }
@@ -187,17 +190,110 @@ app.prepare().then(() => {
   setInterval(() => {
     const now = Date.now();
     const maxAge = 2 * 60 * 60 * 1000; // 2 hours
-    
+
     for (const [gameCode, game] of games.entries()) {
       if (now - game.lastActivity > maxAge) {
         console.log(`Cleaning up old game: ${gameCode}`);
-        
+
         // Remove player mappings
         for (const player of game.players) {
           playerGames.delete(player.id);
         }
-        
+
         games.delete(gameCode);
+      }
+    }
+  }, 5 * 60 * 1000);
+
+  // --- Chess namespace ---
+  const chessNamespace = io.of('/chess');
+
+  chessNamespace.on('connection', (socket) => {
+    console.log(`Chess player connected: ${socket.id}`);
+
+    socket.on('createGame', (data) => {
+      try {
+        const result = chessServer.createGame(data.playerName, socket.id);
+        chessGames.set(result.gameCode, result.game);
+        chessPlayerGames.set(socket.id, result.gameCode);
+        socket.join(result.gameCode);
+        socket.emit('gameCreated', { gameId: result.gameCode, playerId: socket.id });
+        socket.emit('gameStateUpdate', result.game);
+      } catch (e) { socket.emit('error', { message: e.message }); }
+    });
+
+    socket.on('joinGame', (data) => {
+      try {
+        const gameCode = data.gameCode.toUpperCase();
+        const game = chessGames.get(gameCode);
+        if (!game) throw new Error('Game not found');
+        const result = chessServer.joinGame(game, data.playerName, socket.id);
+        chessPlayerGames.set(socket.id, gameCode);
+        socket.join(gameCode);
+        socket.emit('gameJoined', { gameId: gameCode, playerId: socket.id });
+        chessNamespace.to(gameCode).emit('gameStateUpdate', result.game);
+      } catch (e) { socket.emit('error', { message: e.message }); }
+    });
+
+    socket.on('startGame', (data) => {
+      try {
+        const game = chessGames.get(data.gameCode);
+        if (!game) throw new Error('Game not found');
+        const result = chessServer.startGame(game, socket.id);
+        chessNamespace.to(data.gameCode).emit('gameStateUpdate', result.game);
+      } catch (e) { socket.emit('error', { message: e.message }); }
+    });
+
+    socket.on('movePiece', (data) => {
+      try {
+        const game = chessGames.get(data.gameCode);
+        if (!game) throw new Error('Game not found');
+        const result = chessServer.moveChessPiece(game, socket.id, data.from, data.to);
+        chessNamespace.to(data.gameCode).emit('gameStateUpdate', result.game);
+      } catch (e) { socket.emit('error', { message: e.message }); }
+    });
+
+    socket.on('playAgain', (data) => {
+      try {
+        const game = chessGames.get(data.gameCode);
+        if (!game) throw new Error('Game not found');
+        const result = chessServer.playAgain(game, socket.id);
+        chessNamespace.to(data.gameCode).emit('gameStateUpdate', result.game);
+      } catch (e) { socket.emit('error', { message: e.message }); }
+    });
+
+    socket.on('disconnect', () => {
+      const gameCode = chessPlayerGames.get(socket.id);
+      if (gameCode) {
+        const game = chessGames.get(gameCode);
+        if (game) {
+          const player = game.players.find(p => p.id === socket.id);
+          if (player) { player.connected = false; player.lastSeen = Date.now(); }
+          chessNamespace.to(gameCode).emit('gameStateUpdate', game);
+        }
+        chessPlayerGames.delete(socket.id);
+      }
+    });
+
+    socket.on('heartbeat', () => {
+      const gameCode = chessPlayerGames.get(socket.id);
+      if (gameCode) {
+        const game = chessGames.get(gameCode);
+        if (game) {
+          const player = game.players.find(p => p.id === socket.id);
+          if (player) { player.connected = true; player.lastSeen = Date.now(); }
+        }
+      }
+    });
+  });
+
+  setInterval(() => {
+    const now = Date.now();
+    const maxAge = 2 * 60 * 60 * 1000;
+    for (const [code, game] of chessGames.entries()) {
+      if (now - game.lastActivity > maxAge) {
+        for (const p of game.players) chessPlayerGames.delete(p.id);
+        chessGames.delete(code);
       }
     }
   }, 5 * 60 * 1000);


### PR DESCRIPTION
Adds a real-time simultaneous-move chess game at `/chess`.

## Changes
- `lib/chess-server.js` — game logic: simultaneous moves, 1.5s cooldowns per piece, pawn promotion, king-capture win condition
- `pages/chess.tsx` — React page with Socket.IO client, cooldown UI, board flipped for black
- `pages/chess.module.css` — styles
- `server.js` / `game-server-standalone.js` — `/chess` Socket.IO namespace added alongside existing `/who-goes-there`

No Railway config changes needed — chess runs on the same port as the existing game server.

https://claude.ai/code/session_01Md99WbXNnPKSXWhBjd97Xa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Md99WbXNnPKSXWhBjd97Xa)_