### PR TITLE
Add Play vs Bot button to chess lobby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ yarn-error.log*
 .vercel
 .env*.local
 
-.idea
+.ideatsconfig.tsbuildinfo

--- a/pages/chess.module.css
+++ b/pages/chess.module.css
@@ -335,3 +335,24 @@
   text-align: center;
   margin: 0;
 }
+
+/* ── Opponent cursor ── */
+.opponentHover {
+  outline: 2px dashed rgba(74, 144, 217, 0.65);
+  outline-offset: -2px;
+}
+
+.opponentSelected {
+  background: rgba(74, 144, 217, 0.3) !important;
+}
+
+.opponentHand {
+  position: absolute;
+  top: 1px;
+  right: 2px;
+  font-size: clamp(9px, 1.8vw, 13px);
+  line-height: 1;
+  pointer-events: none;
+  z-index: 10;
+  filter: drop-shadow(0 1px 1px rgba(0,0,0,0.3));
+}

--- a/pages/chess.tsx
+++ b/pages/chess.tsx
@@ -18,10 +18,12 @@ interface Player {
   name: string;
   color: Color;
   connected: boolean;
+  isBot?: boolean;
 }
 
 interface ChessGame {
   id: string;
+  singlePlayer?: boolean;
   players: Player[];
   board: Record<string, Piece>;
   cooldowns: Record<string, number>;
@@ -219,6 +221,12 @@ export default function Chess(): React.ReactNode {
 
   // ── Actions ──
 
+  const handlePlayVsBot = () => {
+    if (!socket || !playerName.trim()) return;
+    socket.emit("createSinglePlayerGame", { playerName: playerName.trim() });
+    setJoinMode("create");
+  };
+
   const handleCreate = () => {
     if (!socket || !playerName.trim()) return;
     socket.emit("createGame", { playerName: playerName.trim() });
@@ -385,7 +393,7 @@ export default function Chess(): React.ReactNode {
             placeholder="Your name"
             value={playerName}
             onChange={(e) => setPlayerName(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+            onKeyDown={(e) => e.key === "Enter" && handlePlayVsBot()}
             maxLength={20}
           />
           {joinMode === "join" && (
@@ -398,9 +406,17 @@ export default function Chess(): React.ReactNode {
               autoFocus
             />
           )}
+          <button
+            className={`${styles.btn} ${styles.btnPrimary}`}
+            onClick={handlePlayVsBot}
+            disabled={!playerName.trim() || joinMode === "join"}
+            style={{ width: "100%" }}
+          >
+            Play vs Bot
+          </button>
           <div className={styles.lobbyButtons}>
             <button
-              className={`${styles.btn} ${styles.btnPrimary}`}
+              className={`${styles.btn} ${styles.btnSecondary}`}
               onClick={handleCreate}
               disabled={!playerName.trim() || joinMode === "join"}
             >
@@ -483,7 +499,7 @@ export default function Chess(): React.ReactNode {
             onClick={handlePlayAgain}
             style={{ width: "100%" }}
           >
-            Play again (colors swap)
+            {gameState.singlePlayer ? "Play again" : "Play again (colors swap)"}
           </button>
         </div>
       </div>

--- a/pages/chess.tsx
+++ b/pages/chess.tsx
@@ -128,6 +128,7 @@ export default function Chess(): React.ReactNode {
   const [errorMsg, setErrorMsg] = useState("");
   const [connectionError, setConnectionError] = useState(false);
   const [now, setNow] = useState(Date.now());
+  const [opponentCursor, setOpponentCursor] = useState<{ hover: string | null; selected: string | null }>({ hover: null, selected: null });
 
   // Keep stable refs to avoid stale closures in socket callbacks
   const myColorRef = useRef(myColor);
@@ -136,6 +137,15 @@ export default function Chess(): React.ReactNode {
   gameCodeRef.current = gameCode;
   const playerIdRef = useRef(playerId);
   playerIdRef.current = playerId;
+  const socketRef = useRef<Socket | null>(null);
+  socketRef.current = socket;
+  const selectedSquareRef = useRef<string | null>(null);
+  selectedSquareRef.current = selectedSquare;
+  const hoveredSquareRef = useRef<string | null>(null);
+
+  const emitCursor = useCallback((hover: string | null, selected: string | null) => {
+    socketRef.current?.emit("cursorUpdate", { gameCode: gameCodeRef.current, hover, selected });
+  }, []);
 
   // Tick for cooldown countdowns
   useEffect(() => {
@@ -190,6 +200,10 @@ export default function Chess(): React.ReactNode {
       if (state.gameEnded) { setSelectedSquare(null); setLegalMoves([]); }
     });
 
+    newSocket.on("opponentCursor", (data: { hover: string | null; selected: string | null }) => {
+      setOpponentCursor(data);
+    });
+
     newSocket.on("error", ({ message }: { message: string }) => {
       setErrorMsg(message);
       setTimeout(() => setErrorMsg(""), 3000);
@@ -238,9 +252,11 @@ export default function Chess(): React.ReactNode {
     const coolUntil = gameState.cooldowns?.[sq] ?? 0;
     if (coolUntil > Date.now()) return; // on cooldown
     const moves = getLegalMoves(gameState.board, sq, color);
+    selectedSquareRef.current = sq;
     setSelectedSquare(sq);
     setLegalMoves(moves);
-  }, [gameState]);
+    emitCursor(hoveredSquareRef.current, sq);
+  }, [gameState, emitCursor]);
 
   const handleSquareClick = useCallback((sq: string) => {
     if (!gameState?.gameStarted || gameState.gameEnded || !myColor || !socket || !gameCode) return;
@@ -249,18 +265,22 @@ export default function Chess(): React.ReactNode {
     if (selectedSquare) {
       if (legalMoves.includes(sq)) {
         socket.emit("movePiece", { gameCode, from: selectedSquare, to: sq });
+        selectedSquareRef.current = null;
         setSelectedSquare(null);
         setLegalMoves([]);
+        emitCursor(hoveredSquareRef.current, null);
       } else if (piece && piece.color === myColor) {
         selectSquare(sq);
       } else {
+        selectedSquareRef.current = null;
         setSelectedSquare(null);
         setLegalMoves([]);
+        emitCursor(hoveredSquareRef.current, null);
       }
     } else {
       if (piece && piece.color === myColor) selectSquare(sq);
     }
-  }, [gameState, myColor, socket, gameCode, selectedSquare, legalMoves, selectSquare]);
+  }, [gameState, myColor, socket, gameCode, selectedSquare, legalMoves, selectSquare, emitCursor]);
 
   // ── Render helpers ──
 
@@ -286,6 +306,8 @@ export default function Chess(): React.ReactNode {
 
         const showRankLabel = fi === 0;
         const showFileLabel = ri === 7;
+        const isOpponentSelected = opponentCursor.selected === sq;
+        const isOpponentHover = opponentCursor.hover === sq && !isOpponentSelected;
 
         return (
           <div
@@ -296,8 +318,14 @@ export default function Chess(): React.ReactNode {
               isSelected ? styles.selected : "",
               isLegal && !isCapture ? styles.legalMove : "",
               isCapture ? styles.legalCapture : "",
+              isOpponentSelected ? styles.opponentSelected : "",
+              isOpponentHover ? styles.opponentHover : "",
             ].filter(Boolean).join(" ")}
             onClick={() => handleSquareClick(sq)}
+            onMouseEnter={() => {
+              hoveredSquareRef.current = sq;
+              emitCursor(sq, selectedSquareRef.current);
+            }}
           >
             {showRankLabel && (
               <span className={styles.rankLabel}>{rank}</span>
@@ -323,6 +351,9 @@ export default function Chess(): React.ReactNode {
                   </span>
                 </div>
               </>
+            )}
+            {(isOpponentHover || isOpponentSelected) && (
+              <span className={styles.opponentHand}>👆</span>
             )}
           </div>
         );
@@ -486,7 +517,13 @@ export default function Chess(): React.ReactNode {
           )}
         </div>
 
-        <div className={styles.board}>{renderBoard()}</div>
+        <div
+          className={styles.board}
+          onMouseLeave={() => {
+            hoveredSquareRef.current = null;
+            emitCursor(null, selectedSquareRef.current);
+          }}
+        >{renderBoard()}</div>
 
         {errorMsg && <p className={styles.error}>{errorMsg}</p>}
       </div>


### PR DESCRIPTION
Adds a prominent "Play vs Bot" button to the chess lobby. Single-player games auto-start. Also fixes the end-screen play-again label (no \"colors swap\" text in single-player).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wx2EjQ2LqFKS4JfJA6jony)_