### PR TITLE
Fix .gitignore: split .idea and tsconfig.tsbuildinfo onto separate lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ yarn-error.log*
 .vercel
 .env*.local
 
-.ideatsconfig.tsbuildinfo
+.idea
+tsconfig.tsbuildinfo


### PR DESCRIPTION
The previous append used `echo >>` which concatenated onto a line missing a trailing newline, producing `.ideatsconfig.tsbuildinfo` instead of two separate entries. Fixed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wx2EjQ2LqFKS4JfJA6jony)_