### PR TITLE
Fix dark mode contrast + map selector active state

### DIFF
--- a/pages/chess.module.css
+++ b/pages/chess.module.css
@@ -40,6 +40,8 @@
   border-radius: 8px;
   width: 100%;
   box-sizing: border-box;
+  background: #fff;
+  color: #1a1a1a;
 }
 
 .input:focus {
@@ -107,6 +109,7 @@
   letter-spacing: 0.15em;
   font-family: monospace;
   background: #f0f0f0;
+  color: #1a1a1a;
   padding: 8px 20px;
   border-radius: 8px;
 }
@@ -121,6 +124,7 @@
 .playerList li {
   padding: 8px 12px;
   background: #f5f5f5;
+  color: #1a1a1a;
   border-radius: 6px;
   margin-bottom: 6px;
   display: flex;
@@ -162,6 +166,7 @@
   padding: 4px 10px;
   border-radius: 20px;
   background: #f0f0f0;
+  color: #1a1a1a;
   font-weight: 600;
 }
 
@@ -379,4 +384,19 @@
   flex: 1;
   padding: 8px 12px;
   font-size: 0.875rem;
+}
+
+.mapBtnSelected {
+  background: #1a1a1a;
+  color: #fff;
+  outline: 2px solid #1a1a1a;
+  outline-offset: 2px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .mapBtnSelected {
+    background: #e8e8e8;
+    color: #1a1a1a;
+    outline-color: #e8e8e8;
+  }
 }

--- a/pages/chess.tsx
+++ b/pages/chess.tsx
@@ -471,7 +471,7 @@ export default function Chess(): React.ReactNode {
             {Object.values(CLIENT_MAPS).map(m => (
               <button
                 key={m.id}
-                className={`${styles.btn} ${styles.mapBtn} ${mapId === m.id ? styles.btnPrimary : styles.btnSecondary}`}
+                className={`${styles.btn} ${styles.mapBtn} ${mapId === m.id ? styles.mapBtnSelected : styles.btnSecondary}`}
                 onClick={() => setMapId(m.id)}
               >
                 {m.name}


### PR DESCRIPTION
- Add `color: #1a1a1a` to `.playerTag`, `.playerList li`, `.gameCode`, and `.input` — these had hardcoded light backgrounds but no explicit text color, causing white-on-white in dark mode
- Add `background: #fff` to `.input` so browser dark mode doesn't flip it to a dark background with white text
- Replace `btnPrimary` on the map selector active button with a dedicated `.mapBtnSelected` class that uses an outline indicator and flips to a light background in dark mode, so the selected map is always clearly distinct from the unselected one

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wx2EjQ2LqFKS4JfJA6jony)_