### PR TITLE
Allow bot play on all maps; fix map selector layout

### DIFF
--- a/pages/chess.module.css
+++ b/pages/chess.module.css
@@ -436,18 +436,23 @@
 /* ── Map selector ── */
 .mapSelector {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 6px;
+  width: 100%;
 }
 
 .mapLabel {
   font-size: 0.875rem;
   opacity: 0.6;
-  white-space: nowrap;
+}
+
+.mapGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
 }
 
 .mapBtn {
-  flex: 1;
   padding: 8px 12px;
   font-size: 0.875rem;
 }

--- a/pages/chess.tsx
+++ b/pages/chess.tsx
@@ -582,8 +582,6 @@ export default function Chess(): React.ReactNode {
 
   // Lobby
   if (!gameCode) {
-    const selectedMap = CLIENT_MAPS[mapId] ?? CLIENT_MAPS.standard;
-    const botUnavailable = (selectedMap.maxPlayers ?? 2) > 2;
     return (
       <div className={styles.page}>
         <Head title="Knepprath's Double Check Chess" />
@@ -595,7 +593,7 @@ export default function Chess(): React.ReactNode {
             placeholder="Your name"
             value={playerName}
             onChange={(e) => setPlayerName(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && !botUnavailable && handlePlayVsBot()}
+            onKeyDown={(e) => e.key === "Enter" && handlePlayVsBot()}
             maxLength={20}
           />
           {joinMode === "join" && (
@@ -609,27 +607,27 @@ export default function Chess(): React.ReactNode {
             />
           )}
           <div className={styles.mapSelector}>
-            <span className={styles.mapLabel}>Map:</span>
-            {Object.values(CLIENT_MAPS).map(m => (
-              <button
-                key={m.id}
-                className={`${styles.btn} ${styles.mapBtn} ${mapId === m.id ? styles.mapBtnSelected : styles.btnSecondary}`}
-                onClick={() => setMapId(m.id)}
-              >
-                {m.name}
-              </button>
-            ))}
+            <span className={styles.mapLabel}>Map</span>
+            <div className={styles.mapGrid}>
+              {Object.values(CLIENT_MAPS).map(m => (
+                <button
+                  key={m.id}
+                  className={`${styles.btn} ${styles.mapBtn} ${mapId === m.id ? styles.mapBtnSelected : styles.btnSecondary}`}
+                  onClick={() => setMapId(m.id)}
+                >
+                  {m.name}
+                </button>
+              ))}
+            </div>
           </div>
-          {!botUnavailable && (
-            <button
-              className={`${styles.btn} ${styles.btnPrimary}`}
-              onClick={handlePlayVsBot}
-              disabled={!playerName.trim() || joinMode === "join"}
-              style={{ width: "100%" }}
-            >
-              Play vs Bot
-            </button>
-          )}
+          <button
+            className={`${styles.btn} ${styles.btnPrimary}`}
+            onClick={handlePlayVsBot}
+            disabled={!playerName.trim() || joinMode === "join"}
+            style={{ width: "100%" }}
+          >
+            Play vs Bot
+          </button>
           <div className={styles.lobbyButtons}>
             <button
               className={`${styles.btn} ${styles.btnSecondary}`}


### PR DESCRIPTION
## Summary

- "Play vs Bot" is now available for all maps including Wishbone (3-player) and Switchback (4-player)
- Map selector redesigned as a 2×2 grid — four options fit cleanly without crowding

## Test plan

- [ ] Map selector shows 2×2 grid, all four maps legible
- [ ] "Play vs Bot" visible for all maps
- [ ] Standard and Dumbbell bot games still work as before
- [ ] Wishbone bot game: 2 bots (green + red) each move on independent timers
- [ ] Switchback bot game: 3 bots (green, red, black) each move independently
- [ ] Eliminating a bot stops that bot's loop; game continues

https://claude.ai/code/session_01Wx2EjQ2LqFKS4JfJA6jony

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wx2EjQ2LqFKS4JfJA6jony)_