### PR TITLE
Clarify team mode in waiting room and active game UI

### DIFF
--- a/pages/chess.module.css
+++ b/pages/chess.module.css
@@ -433,6 +433,64 @@
   aspect-ratio: 1;
 }
 
+/* ── Team layouts ── */
+.teamGroups {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.teamGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.teamLabel {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.45;
+}
+
+.teamPlayers {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.teamVs {
+  font-size: 0.8rem;
+  font-weight: 600;
+  opacity: 0.35;
+  padding-top: 22px;
+}
+
+.teamWaitGroups {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+}
+
+.teamWaitGroup {
+  width: 100%;
+}
+
+.teamWaitLabel {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.45;
+  margin: 0 0 4px 0;
+}
+
 /* ── Map selector ── */
 .mapSelector {
   display: flex;

--- a/pages/chess.tsx
+++ b/pages/chess.tsx
@@ -723,25 +723,53 @@ export default function Chess(): React.ReactNode {
     const waitingMap = CLIENT_MAPS[gameState?.mapId ?? mapId] ?? CLIENT_MAPS.standard;
     const maxP = waitingMap.maxPlayers ?? 2;
     const canStart = (gameState?.players.length ?? 0) >= maxP && gameState?.players.some(p => p.id === playerId);
+    const hasTeams = !!waitingMap.teams;
     return (
       <div className={styles.page}>
         <Head title="Knepprath's Double Check Chess" />
         <h1 className={styles.title}>Knepprath&apos;s Double Check Chess</h1>
         <div className={styles.waiting}>
-          <p>Share this code with your {maxP - 1 === 1 ? "opponent" : `${maxP - 1} opponents`}:</p>
+          <p>
+            {hasTeams
+              ? "Share this code to start a 2v2 match:"
+              : `Share this code with your ${maxP - 1 === 1 ? "opponent" : `${maxP - 1} opponents`}:`}
+          </p>
           <div className={styles.gameCode}>{gameCode}</div>
-          <p className={styles.status}>Map: {waitingMap.name} · {maxP} players</p>
-          <ul className={styles.playerList}>
-            {gameState?.players.map((p) => (
-              <li key={p.id}>
-                <span className={`${styles.colorDot} ${styles[`colorDot${p.color.charAt(0).toUpperCase() + p.color.slice(1)}`]}`} />
-                {p.name} {p.id === playerId && "(you)"}
-              </li>
-            ))}
-            {Array.from({ length: Math.max(0, maxP - (gameState?.players.length ?? 0)) }).map((_, i) => (
-              <li key={`empty-${i}`} style={{ opacity: 0.5 }}>Waiting for player…</li>
-            ))}
-          </ul>
+          <p className={styles.status}>
+            {waitingMap.name} · {hasTeams ? "2v2 team mode" : `${maxP} players`}
+          </p>
+          {hasTeams ? (
+            <div className={styles.teamWaitGroups}>
+              {waitingMap.teams!.map((team, ti) => (
+                <div key={ti} className={styles.teamWaitGroup}>
+                  <p className={styles.teamWaitLabel}>Team {ti + 1}</p>
+                  <ul className={styles.playerList}>
+                    {team.map(color => {
+                      const p = gameState?.players.find(pl => pl.color === color);
+                      return (
+                        <li key={color} style={p ? undefined : { opacity: 0.5 }}>
+                          <span className={`${styles.colorDot} ${styles[`colorDot${color.charAt(0).toUpperCase() + color.slice(1)}`]}`} />
+                          {p ? `${p.name}${p.id === playerId ? " (you)" : ""}` : "Waiting for player…"}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <ul className={styles.playerList}>
+              {gameState?.players.map((p) => (
+                <li key={p.id}>
+                  <span className={`${styles.colorDot} ${styles[`colorDot${p.color.charAt(0).toUpperCase() + p.color.slice(1)}`]}`} />
+                  {p.name} {p.id === playerId && "(you)"}
+                </li>
+              ))}
+              {Array.from({ length: Math.max(0, maxP - (gameState?.players.length ?? 0)) }).map((_, i) => (
+                <li key={`empty-${i}`} style={{ opacity: 0.5 }}>Waiting for player…</li>
+              ))}
+            </ul>
+          )}
           <button
             className={`${styles.btn} ${styles.btnPrimary}`}
             onClick={handleStart}
@@ -823,7 +851,43 @@ export default function Chess(): React.ReactNode {
     <div className={styles.page}>
       <Head title="Chess" />
       <div className={styles.gameLayout}>
-        {isMultiPlayer ? (
+        {currentMap.teams ? (
+          <div className={styles.teamGroups} style={{ width: boardWidth }}>
+            {currentMap.teams.map((team, ti) => {
+              const isMyTeam = myColor ? team.includes(myColor) : false;
+              return (
+                <React.Fragment key={ti}>
+                  {ti > 0 && <span className={styles.teamVs}>vs</span>}
+                  <div className={styles.teamGroup}>
+                    <span className={styles.teamLabel}>{isMyTeam ? "Your team" : "Enemy"}</span>
+                    <div className={styles.teamPlayers}>
+                      {team.map(color => {
+                        const p = gameState.players.find(pl => pl.color === color);
+                        if (!p) return null;
+                        const inCheckForP = gameState.inCheck[p.color] ?? false;
+                        const isMe = p.id === playerId;
+                        return (
+                          <div
+                            key={p.id}
+                            className={[
+                              styles.playerTag,
+                              PLAYER_TAG_CSS[p.color],
+                              isMe ? styles.isYou4 : "",
+                              inCheckForP ? styles.inCheck : "",
+                            ].filter(Boolean).join(" ")}
+                          >
+                            <span>{PIECE_GLYPHS[p.color].king}</span>
+                            {p.name}{isMe && " ✓"}{inCheckForP && " ⚠"}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </React.Fragment>
+              );
+            })}
+          </div>
+        ) : isMultiPlayer ? (
           <div className={styles.playerInfo4} style={{ width: boardWidth }}>
             {gameState.players.map(p => {
               const inCheckForP = gameState.inCheck[p.color] ?? false;


### PR DESCRIPTION
## Summary

Makes it visually obvious when you're in a cooperative 2v2 game.

**Waiting room** (team maps only):
- Intro changes to "Share this code to start a 2v2 match:"
- Status shows "2v2 team mode" instead of "4 players"
- Player list replaced with two labeled sections — "Team 1" and "Team 2" — each showing their color-coded slots as players join or remain empty

**Active game** (team maps only):
- Flat 4-tag row replaced with a grouped layout: player tags clustered under "Your team" and "Enemy" labels, separated by a subdued "vs"
- Non-team multiplayer maps (Wishbone) still use the flat row

## Test plan

- [ ] Switchback waiting room shows "2v2 team mode" and two team sections
- [ ] Players joining fill the correct team slot as color is assigned
- [ ] Active game shows "Your team / vs / Enemy" grouping with correct label for your side
- [ ] Wishbone (3-player, no teams) still shows flat player tags
- [ ] Standard/Dumbbell/Archipelago/Ring Road unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wx2EjQ2LqFKS4JfJA6jony)_