### PR TITLE
Fix player tag colors being overridden by base CSS class

### DIFF
--- a/pages/chess.module.css
+++ b/pages/chess.module.css
@@ -145,32 +145,8 @@
 .colorDotRed   { background: #c0392b; }
 .colorDotGreen { background: #27ae60; }
 
-/* ── Player tag colors (4-player) ── */
-.playerTagWhite {
-  background: #f0f0f0;
-  color: #1a1a1a;
-}
-
-.playerTagBlack {
-  background: #2c2c2c;
-  color: #fff;
-}
-
-.playerTagRed {
-  background: #c0392b;
-  color: #fff;
-}
-
-.playerTagGreen {
-  background: #27ae60;
-  color: #fff;
-}
-
-.isYou4 {
-  outline: 2px solid currentColor;
-  outline-offset: 2px;
-  font-weight: 700;
-}
+/* ── Player tag colors (4-player / team) ── */
+/* NOTE: must appear after .playerTag so the color overrides the base background */
 
 /* ── Board ── */
 .gameLayout {
@@ -211,6 +187,32 @@
 .playerTag.isYou {
   background: #1a1a1a;
   color: #fff;
+}
+
+.playerTagWhite {
+  background: #f0f0f0;
+  color: #1a1a1a;
+}
+
+.playerTagBlack {
+  background: #2c2c2c;
+  color: #fff;
+}
+
+.playerTagRed {
+  background: #c0392b;
+  color: #fff;
+}
+
+.playerTagGreen {
+  background: #27ae60;
+  color: #fff;
+}
+
+.isYou4 {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+  font-weight: 700;
 }
 
 .inCheck {


### PR DESCRIPTION
## Problem

`.playerTagRed`, `.playerTagGreen`, `.playerTagBlack` were declared around line 160 in the stylesheet, but `.playerTag` (the base class) was declared at line 200. Since both classes are applied to the same element and have equal specificity, the later rule wins — so `.playerTag`'s `background: #f0f0f0` silently overrode all the color variants. Every player tag rendered as light gray regardless of color.

## Fix

Moved the color variant classes to after `.playerTag` in the stylesheet so they correctly override the base background. Red tags are now red, green tags are green, black tags are dark.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wx2EjQ2LqFKS4JfJA6jony)_