### PR TITLE
Add PSN trophies to the activity feed

### DIFF
--- a/.github/workflows/update-trophies.yml
+++ b/.github/workflows/update-trophies.yml
@@ -1,0 +1,58 @@
+name: Update Trophies
+
+on:
+  schedule:
+    # Run daily at 6:30 AM UTC (1:30 AM ET), half an hour after Update Themes
+    # so the two jobs never race to push to master.
+    - cron: "30 6 * * *"
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-trophies
+  cancel-in-progress: false
+
+jobs:
+  update-trophies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ACTION_GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fetch PSN trophies
+        env:
+          PSN_NPSSO: ${{ secrets.PSN_NPSSO }}
+        run: npx tsx scripts/update-trophies.ts
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet data/trophies.json; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Validate trophies.json
+        if: steps.changes.outputs.changed == 'true'
+        run: node -e "JSON.parse(require('fs').readFileSync('data/trophies.json', 'utf8'))"
+
+      - name: Commit and push to master
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/trophies.json
+          git commit --no-verify -m "Update trophies (automated)"
+          git pull --rebase origin master
+          git push origin master

--- a/core/activity-card.tsx
+++ b/core/activity-card.tsx
@@ -17,7 +17,7 @@ function hashToRotation(id: string): number {
   return ((Math.abs(hash) % 1000) / 1000) * 3 - 1.5;
 }
 
-const STYLED_TYPES = new Set(["RUN", "FILM", "REPO", "MUSIC", "TOOT", "POST", "BOOK", "PHOTO", "CHESS", "ROBOT", "SKEET"]);
+const STYLED_TYPES = new Set(["RUN", "FILM", "REPO", "MUSIC", "TOOT", "POST", "BOOK", "PHOTO", "CHESS", "ROBOT", "SKEET", "TROPHY"]);
 const GLOSSY_TYPES = new Set(["MUSIC", "PHOTO"]);
 
 const typeClassMap: Record<string, string> = {

--- a/core/post/TrophyPost.tsx
+++ b/core/post/TrophyPost.tsx
@@ -8,47 +8,84 @@ interface PostProps extends PostListItem {
   index?: number;
 }
 
+const TIER_CLASS: Record<string, string> = {
+  bronze: styles.trophyBronze,
+  silver: styles.trophySilver,
+  gold: styles.trophyGold,
+  platinum: styles.trophyPlatinum,
+};
+
 const TrophyPost = ({
-  action,
   date,
   id,
   image,
   index = 0,
   summary,
   title,
-  url,
-}: PostProps) => (
-  <ActivityCard id={id} type="TROPHY" index={index}>
-    <article key={id}>
-      <header className={styles.filmPostHeader}>
-        {image ? (
-          <a
-            className={styles.filmPoster}
-            href={url}
-            target="_blank"
-            rel="noreferrer"
-          >
-            <Image
-              alt={`cover image for ${title}`}
-              className="bordered-image corner-radius-8"
-              height={90}
-              src={image}
-              width={90}
-            />
-          </a>
-        ) : null}
-        <div>
-          <a href={url} target="_blank" rel="noreferrer">
-            <h3 className={styles.filmTitle}>{title}</h3>
-          </a>
-          <p style={{ margin: "0.4em 0px 0.2em" }}>{summary}</p>
-          <small>
-            {action} on {format(parseISO(date), "MMMM d, yyyy")}
-          </small>
+}: PostProps) => {
+  // The feed packs the extras into summary as "detail · Key: value · ...",
+  // same trick the chess cards use. Anything without a "Key:" is the detail.
+  const parts = (summary ?? "").split(" · ");
+  const meta: Record<string, string> = {};
+  const detail: string[] = [];
+
+  parts.forEach((part) => {
+    const match = part.match(/^(Game|Tier|Rarity): (.*)$/);
+    if (match) meta[match[1]] = match[2];
+    else if (part.trim()) detail.push(part.trim());
+  });
+
+  const tier = (meta.Tier ?? "").toLowerCase();
+  const rarity = Number(meta.Rarity);
+  const hasRarity = Number.isFinite(rarity);
+
+  return (
+    <ActivityCard id={id} type="TROPHY" index={index}>
+      <article
+        className={`${styles.trophyCard} ${TIER_CLASS[tier] ?? styles.trophyBronze}`}
+      >
+        <div className={styles.trophyGlint} aria-hidden="true" />
+
+        <header className={styles.trophyHeader}>
+          <span className={styles.trophyGame}>{meta.Game ?? "PlayStation"}</span>
+          <span className={styles.trophyDate}>
+            {format(parseISO(date), "MMM d, yyyy")}
+          </span>
+        </header>
+
+        <div className={styles.trophyBody}>
+          {image ? (
+            <div className={styles.trophyIconRing}>
+              <Image
+                alt={`${tier} trophy icon for ${title}`}
+                className={styles.trophyIcon}
+                height={64}
+                src={image}
+                width={64}
+              />
+            </div>
+          ) : null}
+
+          <div className={styles.trophyText}>
+            <p className={styles.trophyUnlocked}>Trophy unlocked</p>
+            <h3 className={styles.trophyName}>{title}</h3>
+            {detail.length ? (
+              <p className={styles.trophyDetail}>{detail.join(" · ")}</p>
+            ) : null}
+          </div>
         </div>
-      </header>
-    </article>
-  </ActivityCard>
-);
+
+        <footer className={styles.trophyFooter}>
+          <span className={styles.trophyTier}>{tier || "trophy"}</span>
+          {hasRarity ? (
+            <span className={styles.trophyRarity}>
+              {rarity}% of players
+            </span>
+          ) : null}
+        </footer>
+      </article>
+    </ActivityCard>
+  );
+};
 
 export default TrophyPost;

--- a/core/post/TrophyPost.tsx
+++ b/core/post/TrophyPost.tsx
@@ -9,10 +9,10 @@ interface PostProps extends PostListItem {
 }
 
 const TIER_CLASS: Record<string, string> = {
-  bronze: styles.trophyBronze,
-  silver: styles.trophySilver,
-  gold: styles.trophyGold,
-  platinum: styles.trophyPlatinum,
+  bronze: styles.slabBronze,
+  silver: styles.slabSilver,
+  gold: styles.slabGold,
+  platinum: styles.slabPlatinum,
 };
 
 const TrophyPost = ({
@@ -23,13 +23,12 @@ const TrophyPost = ({
   summary,
   title,
 }: PostProps) => {
-  // The feed packs the extras into summary as "detail · Key: value · ...",
+  // The feed packs extras into summary as "detail · Key: value · ...", the
   // same trick the chess cards use. Anything without a "Key:" is the detail.
-  const parts = (summary ?? "").split(" · ");
   const meta: Record<string, string> = {};
   const detail: string[] = [];
 
-  parts.forEach((part) => {
+  (summary ?? "").split(" · ").forEach((part) => {
     const match = part.match(/^(Game|Tier|Rarity): (.*)$/);
     if (match) meta[match[1]] = match[2];
     else if (part.trim()) detail.push(part.trim());
@@ -37,52 +36,55 @@ const TrophyPost = ({
 
   const tier = (meta.Tier ?? "").toLowerCase();
   const rarity = Number(meta.Rarity);
-  const hasRarity = Number.isFinite(rarity);
 
   return (
     <ActivityCard id={id} type="TROPHY" index={index}>
-      <article
-        className={`${styles.trophyCard} ${TIER_CLASS[tier] ?? styles.trophyBronze}`}
-      >
-        <div className={styles.trophyGlint} aria-hidden="true" />
-
-        <header className={styles.trophyHeader}>
-          <span className={styles.trophyGame}>{meta.Game ?? "PlayStation"}</span>
-          <span className={styles.trophyDate}>
-            {format(parseISO(date), "MMM d, yyyy")}
+      <article className={`${styles.slab} ${TIER_CLASS[tier] ?? styles.slabBronze}`}>
+        {/* Printed grading label, read through the plastic. */}
+        <header className={styles.slabLabel}>
+          <span className={styles.slabGame}>{meta.Game ?? "PlayStation"}</span>
+          <span className={styles.slabGrade}>
+            {Number.isFinite(rarity) ? (
+              <>
+                <span className={styles.slabGradeLabel}>Rarity</span>
+                <span className={styles.slabGradeValue}>{rarity}</span>
+              </>
+            ) : null}
+            <span className={styles.slabTier}>{tier || "trophy"}</span>
           </span>
         </header>
 
-        <div className={styles.trophyBody}>
+        {/* Recessed well holding the struck medallion. */}
+        <div className={styles.slabWell}>
           {image ? (
-            <div className={styles.trophyIconRing}>
-              <Image
-                alt={`${tier} trophy icon for ${title}`}
-                className={styles.trophyIcon}
-                height={64}
-                src={image}
-                width={64}
-              />
+            <div className={styles.slabMedallion}>
+              <div className={styles.slabMedallionInner}>
+                <Image
+                  alt={`${tier} trophy medallion for ${title}`}
+                  className={styles.slabIcon}
+                  height={72}
+                  src={image}
+                  width={72}
+                />
+              </div>
             </div>
           ) : null}
 
-          <div className={styles.trophyText}>
-            <p className={styles.trophyUnlocked}>Trophy unlocked</p>
-            <h3 className={styles.trophyName}>{title}</h3>
+          <div className={styles.slabText}>
+            <h3 className={styles.slabTitle}>{title}</h3>
             {detail.length ? (
-              <p className={styles.trophyDetail}>{detail.join(" · ")}</p>
+              <p className={styles.slabDetail}>{detail.join(" · ")}</p>
             ) : null}
           </div>
         </div>
 
-        <footer className={styles.trophyFooter}>
-          <span className={styles.trophyTier}>{tier || "trophy"}</span>
-          {hasRarity ? (
-            <span className={styles.trophyRarity}>
-              {rarity}% of players
-            </span>
-          ) : null}
+        {/* Tamper seal. */}
+        <footer className={styles.slabSeal}>
+          <span className={styles.slabSealMark}>Sealed</span>
+          <span>{format(parseISO(date), "MMM d, yyyy")}</span>
         </footer>
+
+        <div className={styles.slabSheen} aria-hidden="true" />
       </article>
     </ActivityCard>
   );

--- a/core/post/post.module.css
+++ b/core/post/post.module.css
@@ -1443,10 +1443,10 @@
   margin-top: 5px;
   padding: 16px 16px 14px;
   border-radius: 2px 2px 6px 6px;
-  background: linear-gradient(180deg, #20262f 0%, #171c24 100%);
+  background: linear-gradient(180deg, #f4f7fa 0%, #e7edf3 100%);
   box-shadow:
-    inset 0 2px 5px rgba(0, 0, 0, 0.55),
-    inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+    inset 0 2px 5px rgba(70, 85, 100, 0.22),
+    inset 0 0 0 1px rgba(120, 135, 150, 0.16);
 }
 
 /* Struck medallion, raised rim in the tier's metal. */
@@ -1474,7 +1474,7 @@
   border-radius: 50%;
   overflow: hidden;
   line-height: 0;
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.5);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.35);
 }
 .slabIcon {
   display: block;
@@ -1490,13 +1490,13 @@
   margin: 0;
   font-size: 17px;
   line-height: 1.25;
-  color: #f4f7fa;
+  color: #1d2530;
 }
 .slabDetail {
   margin: 5px 0 0;
   font-size: 13px;
   line-height: 1.4;
-  color: #98a3b3;
+  color: #5c6875;
 }
 
 /* ── Tamper seal along the bottom ── */
@@ -1567,6 +1567,18 @@
   }
   .slabLabel {
     background: #ece7dc;
+  }
+  .slabWell {
+    background: linear-gradient(180deg, #20262f 0%, #171c24 100%);
+    box-shadow:
+      inset 0 2px 5px rgba(0, 0, 0, 0.55),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  }
+  .slabTitle {
+    color: #f4f7fa;
+  }
+  .slabDetail {
+    color: #98a3b3;
   }
   .slabSeal {
     /* The seal is a detail, not a panel — keep it near the shell's value so

--- a/core/post/post.module.css
+++ b/core/post/post.module.css
@@ -1318,3 +1318,190 @@
     border-color: #1a3a1a;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Trophy cards — PlayStation's trophy-unlocked notification: a dark slab with
+   the tier's metal running through the accent, icon ring and footer.
+   --------------------------------------------------------------------------- */
+.trophyCard {
+  composes: paperNoise;
+  position: relative;
+  overflow: hidden;
+  display: block;
+  border-radius: 6px;
+  padding: 14px 18px 12px;
+  background: linear-gradient(160deg, #20293a 0%, #161d2b 100%);
+  border-top: 2px solid var(--trophy-metal);
+  box-shadow:
+    0px 2px 6px rgba(0, 0, 0, 0.18),
+    0px 8px 20px rgba(0, 0, 0, 0.12);
+  transition: box-shadow 0.2s;
+}
+.trophyCard:hover {
+  box-shadow:
+    0px 4px 12px rgba(0, 0, 0, 0.24),
+    0px 14px 30px rgba(0, 0, 0, 0.18);
+}
+
+/* Tier metals. Each sets the accent colour the rest of the card reads from. */
+.trophyBronze {
+  --trophy-metal: #cd7f32;
+  --trophy-glow: rgba(205, 127, 50, 0.35);
+}
+.trophySilver {
+  --trophy-metal: #b8c2cc;
+  --trophy-glow: rgba(184, 194, 204, 0.35);
+}
+.trophyGold {
+  --trophy-metal: #e8b923;
+  --trophy-glow: rgba(232, 185, 35, 0.35);
+}
+.trophyPlatinum {
+  --trophy-metal: #7ec8e3;
+  --trophy-glow: rgba(126, 200, 227, 0.4);
+}
+
+/* A single slow sheen across the metal, like the console's unlock animation. */
+.trophyGlint {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    115deg,
+    transparent 40%,
+    var(--trophy-glow) 50%,
+    transparent 60%
+  );
+  opacity: 0;
+  transform: translateX(-60%);
+}
+.trophyCard:hover .trophyGlint {
+  animation: trophySweep 0.9s ease-out;
+}
+@keyframes trophySweep {
+  0% {
+    opacity: 0;
+    transform: translateX(-60%);
+  }
+  35% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(60%);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .trophyCard:hover .trophyGlint {
+    animation: none;
+  }
+}
+
+.trophyHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.trophyGame {
+  font-size: 10px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--trophy-metal);
+  font-family: Consolas, Monaco, monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.trophyDate {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: #7c8798;
+  white-space: nowrap;
+}
+
+.trophyBody {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+/* Icon sits in a ring of its own metal, as trophies do on the console. */
+.trophyIconRing {
+  flex: none;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  padding: 3px;
+  background: linear-gradient(145deg, var(--trophy-metal), rgba(0, 0, 0, 0.35));
+  box-shadow: 0 0 12px var(--trophy-glow);
+}
+.trophyIcon {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.trophyText {
+  min-width: 0;
+}
+.trophyUnlocked {
+  margin: 0 0 2px;
+  font-size: 9px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: #6f7a8b;
+  font-family: Consolas, Monaco, monospace;
+}
+.trophyName {
+  margin: 0;
+  font-size: 17px;
+  line-height: 1.25;
+  color: #f2f5f9;
+}
+.trophyDetail {
+  margin: 4px 0 0;
+  font-size: 13px;
+  line-height: 1.4;
+  color: #9aa6b6;
+}
+
+.trophyFooter {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 12px;
+  padding-top: 9px;
+  border-top: 1px solid #2a3444;
+}
+.trophyTier {
+  font-size: 10px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: #10161f;
+  background: var(--trophy-metal);
+  border-radius: 3px;
+  padding: 2px 7px;
+  font-family: Consolas, Monaco, monospace;
+}
+.trophyRarity {
+  font-size: 11px;
+  color: #7c8798;
+  font-family: Consolas, Monaco, monospace;
+}
+
+/* The card is dark by design, so light mode only softens the surround. */
+@media (prefers-color-scheme: light) {
+  .trophyCard {
+    box-shadow:
+      0px 2px 6px rgba(0, 0, 0, 0.1),
+      0px 8px 20px rgba(0, 0, 0, 0.06);
+  }
+}

--- a/core/post/post.module.css
+++ b/core/post/post.module.css
@@ -1319,189 +1319,266 @@
   }
 }
 
-/* ---------------------------------------------------------------------------
-   Trophy cards — PlayStation's trophy-unlocked notification: a dark slab with
-   the tier's metal running through the accent, icon ring and footer.
-   --------------------------------------------------------------------------- */
-.trophyCard {
-  composes: paperNoise;
-  position: relative;
-  overflow: hidden;
+/* ─────────────────────────────────────────────────
+   TROPHY — graded collector slab
+   Medallion sealed in rigid acrylic. Printed grading
+   label up top, recessed well, tamper seal below.
+   Rarity is the grade.
+   ───────────────────────────────────────────────── */
+
+.slab {
   display: block;
-  border-radius: 6px;
-  padding: 14px 18px 12px;
-  background: linear-gradient(160deg, #20293a 0%, #161d2b 100%);
-  border-top: 2px solid var(--trophy-metal);
+  position: relative;
+  border-radius: 10px;
+  padding: 9px 9px 8px;
+  /* The acrylic itself: cool, slightly translucent, brighter at the top edge
+     where the light catches the bevel. */
+  background: linear-gradient(
+    165deg,
+    #fdfdfe 0%,
+    #eef1f5 18%,
+    #e4e9ef 55%,
+    #dde3ea 100%
+  );
   box-shadow:
-    0px 2px 6px rgba(0, 0, 0, 0.18),
-    0px 8px 20px rgba(0, 0, 0, 0.12);
+    inset 0 1px 0 rgba(255, 255, 255, 0.9),
+    inset 0 0 0 1px rgba(120, 135, 150, 0.28),
+    0px 2px 6px rgba(0, 0, 0, 0.12),
+    0px 10px 24px rgba(0, 0, 0, 0.09);
   transition: box-shadow 0.2s;
 }
-.trophyCard:hover {
+.slab:hover {
   box-shadow:
-    0px 4px 12px rgba(0, 0, 0, 0.24),
-    0px 14px 30px rgba(0, 0, 0, 0.18);
+    inset 0 1px 0 rgba(255, 255, 255, 0.9),
+    inset 0 0 0 1px rgba(120, 135, 150, 0.28),
+    0px 5px 12px rgba(0, 0, 0, 0.15),
+    0px 16px 34px rgba(0, 0, 0, 0.11);
 }
 
-/* Tier metals. Each sets the accent colour the rest of the card reads from. */
-.trophyBronze {
-  --trophy-metal: #cd7f32;
-  --trophy-glow: rgba(205, 127, 50, 0.35);
-}
-.trophySilver {
-  --trophy-metal: #b8c2cc;
-  --trophy-glow: rgba(184, 194, 204, 0.35);
-}
-.trophyGold {
-  --trophy-metal: #e8b923;
-  --trophy-glow: rgba(232, 185, 35, 0.35);
-}
-.trophyPlatinum {
-  --trophy-metal: #7ec8e3;
-  --trophy-glow: rgba(126, 200, 227, 0.4);
-}
-
-/* A single slow sheen across the metal, like the console's unlock animation. */
-.trophyGlint {
+/* Specular sweep across the plastic. */
+.slabSheen {
   position: absolute;
   inset: 0;
+  border-radius: inherit;
   pointer-events: none;
   background: linear-gradient(
-    115deg,
-    transparent 40%,
-    var(--trophy-glow) 50%,
-    transparent 60%
+    118deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.55) 45%,
+    rgba(255, 255, 255, 0.15) 52%,
+    transparent 66%
   );
-  opacity: 0;
-  transform: translateX(-60%);
-}
-.trophyCard:hover .trophyGlint {
-  animation: trophySweep 0.9s ease-out;
-}
-@keyframes trophySweep {
-  0% {
-    opacity: 0;
-    transform: translateX(-60%);
-  }
-  35% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-    transform: translateX(60%);
-  }
-}
-@media (prefers-reduced-motion: reduce) {
-  .trophyCard:hover .trophyGlint {
-    animation: none;
-  }
+  opacity: 0.55;
 }
 
-.trophyHeader {
+/* ── Printed grading label, slipped in behind the plastic ── */
+.slabLabel {
+  composes: paperNoise;
+  position: relative;
   display: flex;
+  align-items: stretch;
   justify-content: space-between;
-  align-items: baseline;
-  gap: 12px;
-  margin-bottom: 10px;
+  gap: 10px;
+  background: #fbf8f1;
+  border-radius: 6px 6px 2px 2px;
+  border-bottom: 2px solid var(--slab-metal);
+  padding: 7px 10px 6px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 }
-.trophyGame {
+.slabGame {
+  font-family: Consolas, Monaco, monospace;
   font-size: 10px;
   font-weight: bold;
   text-transform: uppercase;
-  letter-spacing: 1.5px;
-  color: var(--trophy-metal);
-  font-family: Consolas, Monaco, monospace;
+  letter-spacing: 1.6px;
+  color: #3d4652;
+  align-self: center;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.trophyDate {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
-  color: #7c8798;
-  white-space: nowrap;
-}
-
-.trophyBody {
+/* The grade block — the bit collectors actually look at. */
+.slabGrade {
+  flex: none;
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 7px;
+  padding: 3px 9px;
+  border-radius: 3px;
+  background: var(--slab-metal);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
 }
-
-/* Icon sits in a ring of its own metal, as trophies do on the console. */
-.trophyIconRing {
-  flex: none;
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
-  padding: 3px;
-  background: linear-gradient(145deg, var(--trophy-metal), rgba(0, 0, 0, 0.35));
-  box-shadow: 0 0 12px var(--trophy-glow);
+.slabGradeLabel {
+  font-family: Consolas, Monaco, monospace;
+  font-size: 8px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1.4px;
+  color: rgba(20, 24, 30, 0.62);
 }
-.trophyIcon {
-  display: block;
-  width: 100%;
-  height: 100%;
-  border-radius: 50%;
-  object-fit: cover;
+.slabGradeValue {
+  font-family: Consolas, Monaco, monospace;
+  font-size: 14px;
+  font-weight: bold;
+  line-height: 1;
+  color: #14181e;
 }
-
-.trophyText {
-  min-width: 0;
-}
-.trophyUnlocked {
-  margin: 0 0 2px;
+.slabTier {
+  font-family: Consolas, Monaco, monospace;
   font-size: 9px;
   font-weight: bold;
   text-transform: uppercase;
-  letter-spacing: 2px;
-  color: #6f7a8b;
-  font-family: Consolas, Monaco, monospace;
+  letter-spacing: 1.4px;
+  color: rgba(20, 24, 30, 0.75);
+  border-left: 1px solid rgba(20, 24, 30, 0.28);
+  padding-left: 7px;
 }
-.trophyName {
+
+/* ── The recessed well the medallion sits in ── */
+.slabWell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 5px;
+  padding: 16px 16px 14px;
+  border-radius: 2px 2px 6px 6px;
+  background: linear-gradient(180deg, #20262f 0%, #171c24 100%);
+  box-shadow:
+    inset 0 2px 5px rgba(0, 0, 0, 0.55),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+/* Struck medallion, raised rim in the tier's metal. */
+.slabMedallion {
+  flex: none;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  padding: 4px;
+  background: conic-gradient(
+    from 210deg,
+    var(--slab-metal) 0deg,
+    rgba(255, 255, 255, 0.85) 70deg,
+    var(--slab-metal) 150deg,
+    rgba(0, 0, 0, 0.45) 250deg,
+    var(--slab-metal) 360deg
+  );
+  box-shadow:
+    0 2px 5px rgba(0, 0, 0, 0.5),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.3);
+}
+.slabMedallionInner {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  overflow: hidden;
+  line-height: 0;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.5);
+}
+.slabIcon {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.slabText {
+  min-width: 0;
+}
+.slabTitle {
   margin: 0;
   font-size: 17px;
   line-height: 1.25;
-  color: #f2f5f9;
+  color: #f4f7fa;
 }
-.trophyDetail {
-  margin: 4px 0 0;
+.slabDetail {
+  margin: 5px 0 0;
   font-size: 13px;
   line-height: 1.4;
-  color: #9aa6b6;
+  color: #98a3b3;
 }
 
-.trophyFooter {
+/* ── Tamper seal along the bottom ── */
+.slabSeal {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 10px;
-  margin-top: 12px;
-  padding-top: 9px;
-  border-top: 1px solid #2a3444;
-}
-.trophyTier {
-  font-size: 10px;
-  font-weight: bold;
+  margin-top: 4px;
+  padding: 3px 9px;
+  border-radius: 2px 2px 5px 5px;
+  font-family: Consolas, Monaco, monospace;
+  font-size: 8px;
   text-transform: uppercase;
   letter-spacing: 1.5px;
-  color: #10161f;
-  background: var(--trophy-metal);
-  border-radius: 3px;
-  padding: 2px 7px;
-  font-family: Consolas, Monaco, monospace;
+  color: #5d6875;
+  /* Fine diagonal hatching, like a holographic security strip. */
+  background: repeating-linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.6) 0px,
+      rgba(255, 255, 255, 0.6) 2px,
+      rgba(196, 206, 217, 0.5) 2px,
+      rgba(196, 206, 217, 0.5) 4px
+    ),
+    #dfe5ec;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.08);
 }
-.trophyRarity {
-  font-size: 11px;
-  color: #7c8798;
-  font-family: Consolas, Monaco, monospace;
+.slabSealMark {
+  color: var(--slab-ink);
+  font-weight: bold;
 }
 
-/* The card is dark by design, so light mode only softens the surround. */
-@media (prefers-color-scheme: light) {
-  .trophyCard {
+/* ── Tier metals ── */
+.slabBronze {
+  --slab-metal: #c8813f;
+  --slab-ink: #9a5f27;
+}
+.slabSilver {
+  --slab-metal: #c2cad2;
+  --slab-ink: #737f8c;
+}
+.slabGold {
+  --slab-metal: #e6bb35;
+  --slab-ink: #a37f0d;
+}
+.slabPlatinum {
+  --slab-metal: #96d4e8;
+  --slab-ink: #3f8ba3;
+}
+
+@media (prefers-color-scheme: dark) {
+  .slab {
+    background: linear-gradient(
+      165deg,
+      #4a525d 0%,
+      #39414b 20%,
+      #2c333c 60%,
+      #262c34 100%
+    );
     box-shadow:
-      0px 2px 6px rgba(0, 0, 0, 0.1),
-      0px 8px 20px rgba(0, 0, 0, 0.06);
+      inset 0 1px 0 rgba(255, 255, 255, 0.16),
+      inset 0 0 0 1px rgba(0, 0, 0, 0.5),
+      0px 2px 6px rgba(0, 0, 0, 0.4),
+      0px 10px 24px rgba(0, 0, 0, 0.3);
+  }
+  .slabSheen {
+    opacity: 0.22;
+  }
+  .slabLabel {
+    background: #ece7dc;
+  }
+  .slabSeal {
+    /* The seal is a detail, not a panel — keep it near the shell's value so
+       it recedes behind the printed label. */
+    background: repeating-linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.055) 0px,
+        rgba(255, 255, 255, 0.055) 2px,
+        rgba(0, 0, 0, 0.16) 2px,
+        rgba(0, 0, 0, 0.16) 4px
+      ),
+      #333a44;
+    color: #6f7b89;
   }
 }

--- a/data/trophies.json
+++ b/data/trophies.json
@@ -1,0 +1,402 @@
+[
+  {
+    "id": "tNPWR39871_00-12",
+    "title": "Life finds a way",
+    "summary": "Have your first baby animal born in your zoo",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR39871_00/d81814ba-b7f6-4583-aebb-b318e13228e5.png",
+    "date": "2025-12-17T00:56:01Z",
+    "game": "Planet Zoo",
+    "type": "bronze",
+    "rarity": "20.7"
+  },
+  {
+    "id": "tNPWR44031_00-4",
+    "title": "The Duchess Joins the Fray",
+    "summary": "The Duchess became a playable character",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR44031_00/e1faa84f-c132-485e-86bc-9d87f3b90997.png",
+    "date": "2025-07-16T01:24:07Z",
+    "game": "ELDEN RING NIGHTREIGN",
+    "type": "bronze",
+    "rarity": "71.4"
+  },
+  {
+    "id": "tNPWR44031_00-16",
+    "title": "Relic",
+    "summary": "Invoked the power of a relic for the first time",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR44031_00/59f85222-0e0d-4567-810e-1ed9100d5d75.png",
+    "date": "2025-07-14T01:34:05Z",
+    "game": "ELDEN RING NIGHTREIGN",
+    "type": "bronze",
+    "rarity": "81.4"
+  },
+  {
+    "id": "tNPWR44031_00-1",
+    "title": "The Shrouded Roundtable Hold",
+    "summary": "Reached the Shrouded Roundtable Hold",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR44031_00/b80ec555-cff2-4c16-8640-60e78c740854.png",
+    "date": "2025-07-14T01:14:37Z",
+    "game": "ELDEN RING NIGHTREIGN",
+    "type": "bronze",
+    "rarity": "93.3"
+  },
+  {
+    "id": "tNPWR30405_00-37",
+    "title": "Slice like you",
+    "summary": "Slice 20 terminals",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR30405_00/fd655623-af76-467d-9856-a6a2d5d1090f.png",
+    "date": "2025-01-09T04:44:36Z",
+    "game": "Star Wars Outlaws",
+    "type": "bronze",
+    "rarity": "29.7"
+  },
+  {
+    "id": "tNPWR30405_00-10",
+    "title": "Give me the good stuff",
+    "summary": "Buy an item from a merchant's VIP stock",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR30405_00/b1a93b21-55da-4328-b5a0-a7dff7882398.png",
+    "date": "2025-01-09T04:04:16Z",
+    "game": "Star Wars Outlaws",
+    "type": "bronze",
+    "rarity": "30.4"
+  },
+  {
+    "id": "tNPWR34927_00-10",
+    "title": "Ace",
+    "summary": "Get 3 hole in ones",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR34927_00/d3e991ff-c6a1-4f15-b2a4-d7f813876968.png",
+    "date": "2025-01-03T17:57:49Z",
+    "game": "Walkabout Mini Golf",
+    "type": "silver",
+    "rarity": "15.4"
+  },
+  {
+    "id": "tNPWR34927_00-11",
+    "title": "Eagle",
+    "summary": "Score 2 under par on a single hole",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR34927_00/65da2838-db79-41ff-a408-e48d332aabcb.png",
+    "date": "2025-01-03T04:50:31Z",
+    "game": "Walkabout Mini Golf",
+    "type": "silver",
+    "rarity": "35.2"
+  },
+  {
+    "id": "tNPWR34927_00-18",
+    "title": "Fore!",
+    "summary": "Hit the ball out of bounds",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR34927_00/5ed06c01-fdb4-44c9-931c-2e72235c964e.png",
+    "date": "2025-01-03T04:43:03Z",
+    "game": "Walkabout Mini Golf",
+    "type": "bronze",
+    "rarity": "63.3"
+  },
+  {
+    "id": "tNPWR34927_00-19",
+    "title": "First of Many",
+    "summary": "Complete any hole",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR34927_00/10527bee-d989-4d64-b998-770094de27d1.png",
+    "date": "2025-01-03T04:42:50Z",
+    "game": "Walkabout Mini Golf",
+    "type": "bronze",
+    "rarity": "65.4"
+  },
+  {
+    "id": "tNPWR27777_00-16",
+    "title": "Mastered the Elements",
+    "summary": "Crafted Elemental Ammo",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR27777_00/758aad02-3e36-4482-8692-72d580fdbfb0.png",
+    "date": "2024-12-26T21:29:51Z",
+    "game": "Horizon Call of the Mountain",
+    "type": "bronze",
+    "rarity": "50.8"
+  },
+  {
+    "id": "tNPWR27777_00-14",
+    "title": "Crafted Pickaxes",
+    "summary": "Crafted your Pickaxes",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR27777_00/90fe8119-53ee-41e8-9ca5-6ff196b8ccab.png",
+    "date": "2024-12-26T21:24:20Z",
+    "game": "Horizon Call of the Mountain",
+    "type": "bronze",
+    "rarity": "47.6"
+  },
+  {
+    "id": "tNPWR27777_00-30",
+    "title": "Carja in Shadow",
+    "summary": "Got through a Watcher Stealth Area Undetected",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR27777_00/3e23579d-74c7-42e5-8422-0ca238b54990.png",
+    "date": "2024-12-26T20:31:43Z",
+    "game": "Horizon Call of the Mountain",
+    "type": "bronze",
+    "rarity": "12.4"
+  },
+  {
+    "id": "tNPWR27777_00-9",
+    "title": "A Rock to the Head",
+    "summary": "Climbed Brightdawn to the view of Dawn's Grasp",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR27777_00/250c916e-f95b-4f55-a588-6de7659ff19f.png",
+    "date": "2024-12-25T01:31:16Z",
+    "game": "Horizon Call of the Mountain",
+    "type": "bronze",
+    "rarity": "70.4"
+  },
+  {
+    "id": "tNPWR27777_00-23",
+    "title": "Collector",
+    "summary": "Found a Lore Collectible in Horizon Call of the Mountain",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR27777_00/2b0b4f39-d839-42d5-97aa-46e38207dfc5.png",
+    "date": "2024-12-25T01:26:27Z",
+    "game": "Horizon Call of the Mountain",
+    "type": "bronze",
+    "rarity": "69.4"
+  },
+  {
+    "id": "tNPWR27777_00-18",
+    "title": "Warning Beacon",
+    "summary": "Shot a Warning Beacon",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR27777_00/a0229ca8-de29-4226-aebe-df6466be0982.png",
+    "date": "2024-12-25T01:15:27Z",
+    "game": "Horizon Call of the Mountain",
+    "type": "bronze",
+    "rarity": "83.2"
+  },
+  {
+    "id": "tNPWR20842_00-6",
+    "title": "This Crystal Is My Things",
+    "summary": "Acquire Phase Quartz",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR20842_00/ec455565-9046-44b5-ad0a-2618b0258443.png",
+    "date": "2024-11-13T00:20:46Z",
+    "game": "Ratchet & Clank: Rift Apart",
+    "type": "bronze",
+    "rarity": "42.6"
+  },
+  {
+    "id": "tNPWR20842_00-3",
+    "title": "Victory!",
+    "summary": "Complete a Battleplex Challenge",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR20842_00/d9a26596-8e3f-4e2c-90b0-c53a511155c9.png",
+    "date": "2024-11-10T16:46:58Z",
+    "game": "Ratchet & Clank: Rift Apart",
+    "type": "bronze",
+    "rarity": "52.7"
+  },
+  {
+    "id": "tNPWR20842_00-36",
+    "title": "Extreme Gardening",
+    "summary": "Defeat 30 Enemies While They are Topiary'd",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR20842_00/a5bed567-802f-4906-9a4f-3befd3a80d93.png",
+    "date": "2024-11-10T16:28:07Z",
+    "game": "Ratchet & Clank: Rift Apart",
+    "type": "bronze",
+    "rarity": "26.9"
+  },
+  {
+    "id": "tNPWR20842_00-16",
+    "title": "Sartorial Steel",
+    "summary": "Acquire a Piece of Armor",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR20842_00/8bf01115-308e-4737-9682-ec8f2e20d087.png",
+    "date": "2024-11-10T16:22:34Z",
+    "game": "Ratchet & Clank: Rift Apart",
+    "type": "bronze",
+    "rarity": "59.1"
+  },
+  {
+    "id": "tNPWR20842_00-37",
+    "title": "It's So Fluffy!",
+    "summary": "Find a CraiggerBear",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR20842_00/e0a12773-9f93-4ffc-baaf-3d7582a2c364.png",
+    "date": "2024-11-10T16:12:07Z",
+    "game": "Ratchet & Clank: Rift Apart",
+    "type": "bronze",
+    "rarity": "51.0"
+  },
+  {
+    "id": "tNPWR20842_00-20",
+    "title": "Quantum Mechanic",
+    "summary": "Repair a Dimensional Anomaly",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR20842_00/48a071e2-364b-43b5-a976-5371173dbe9b.png",
+    "date": "2024-11-10T16:06:22Z",
+    "game": "Ratchet & Clank: Rift Apart",
+    "type": "bronze",
+    "rarity": "58.3"
+  },
+  {
+    "id": "tNPWR20842_00-2",
+    "title": "Hide 'N Seekerpede",
+    "summary": "Defeat the Seekerpede",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR20842_00/ff148828-1cd1-4e8e-bc04-e22fb93845d3.png",
+    "date": "2024-11-10T15:55:22Z",
+    "game": "Ratchet & Clank: Rift Apart",
+    "type": "bronze",
+    "rarity": "55.7"
+  },
+  {
+    "id": "tNPWR20842_00-18",
+    "title": "Shiny!",
+    "summary": "Collect a Gold Bolt",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR20842_00/7596aa1a-fe5b-4179-b79d-9728d7faf09b.png",
+    "date": "2024-11-09T23:36:02Z",
+    "game": "Ratchet & Clank: Rift Apart",
+    "type": "bronze",
+    "rarity": "53.4"
+  },
+  {
+    "id": "tNPWR20842_00-15",
+    "title": "More Than Lint",
+    "summary": "Enter a Hidden Pocket Dimension",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR20842_00/7a557d2c-bb15-4cda-93ee-cab4358be1e0.png",
+    "date": "2024-11-09T23:12:07Z",
+    "game": "Ratchet & Clank: Rift Apart",
+    "type": "bronze",
+    "rarity": "63.6"
+  },
+  {
+    "id": "tNPWR20842_00-21",
+    "title": "They Blow Up So Fast",
+    "summary": "Get a Weapon to Level Five",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR20842_00/0f42fc52-0935-4ab3-8af8-644e88bdf5b8.png",
+    "date": "2024-11-07T22:52:12Z",
+    "game": "Ratchet & Clank: Rift Apart",
+    "type": "silver",
+    "rarity": "57.3"
+  },
+  {
+    "id": "tNPWR20842_00-1",
+    "title": "Rift Apart",
+    "summary": "Get Separated in Nefarious City",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR20842_00/ddb63b52-620d-46b2-8378-67ae87ffebc0.png",
+    "date": "2024-11-07T22:20:34Z",
+    "game": "Ratchet & Clank: Rift Apart",
+    "type": "bronze",
+    "rarity": "74.8"
+  },
+  {
+    "id": "tNPWR30405_00-44",
+    "title": "Rare friends",
+    "summary": "Complete all main quests on Tatooine",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR30405_00/c5e705b2-b610-4636-812b-924d77d9b7d4.png",
+    "date": "2024-10-27T22:56:04Z",
+    "game": "Star Wars Outlaws",
+    "type": "bronze",
+    "rarity": "26.2"
+  },
+  {
+    "id": "tNPWR30405_00-43",
+    "title": "Making friends",
+    "summary": "Escape from Jabba's palace",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR30405_00/48a61287-86e2-44e5-8157-991a983af77d.png",
+    "date": "2024-10-11T00:11:58Z",
+    "game": "Star Wars Outlaws",
+    "type": "bronze",
+    "rarity": "26.9"
+  },
+  {
+    "id": "tNPWR30405_00-36",
+    "title": "Into the main frame",
+    "summary": "Slice 10 advanced terminals",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR30405_00/9642232f-bcfb-49b6-8198-3b77597c47c3.png",
+    "date": "2024-10-10T23:33:39Z",
+    "game": "Star Wars Outlaws",
+    "type": "silver",
+    "rarity": "27.4"
+  },
+  {
+    "id": "tNPWR30405_00-41",
+    "title": "Tip the scales",
+    "summary": "Complete all main quests on Toshara",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR30405_00/fa4ad99b-168d-4d86-a462-74aac9e044b7.png",
+    "date": "2024-09-24T22:16:34Z",
+    "game": "Star Wars Outlaws",
+    "type": "bronze",
+    "rarity": "35.2"
+  },
+  {
+    "id": "tNPWR30405_00-7",
+    "title": "Good listener",
+    "summary": "Listen to the longest sob story in the galaxy",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR30405_00/d0260444-b43b-46a2-8080-985c73d7b49f.png",
+    "date": "2024-09-21T23:43:18Z",
+    "game": "Star Wars Outlaws",
+    "type": "bronze",
+    "rarity": "23.2"
+  },
+  {
+    "id": "tNPWR30405_00-25",
+    "title": "How rude!",
+    "summary": "Blind 30 enemies with Nix attacks",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR30405_00/8fc67bb3-b4b7-440f-bc6c-3b90c31d1fad.png",
+    "date": "2024-09-21T22:39:59Z",
+    "game": "Star Wars Outlaws",
+    "type": "bronze",
+    "rarity": "3.1"
+  },
+  {
+    "id": "tNPWR30405_00-38",
+    "title": "Now you see me, now you don't",
+    "summary": "Disable an alarm using a security terminal while the alarm is active",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR30405_00/7f11c184-144b-466f-9804-9a86f91c7791.png",
+    "date": "2024-09-21T22:14:46Z",
+    "game": "Star Wars Outlaws",
+    "type": "bronze",
+    "rarity": "54.4"
+  },
+  {
+    "id": "tNPWR30405_00-39",
+    "title": "Get rhythm",
+    "summary": "Pick 20 locks with the data spike",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR30405_00/9197b5b9-3001-47b2-9472-8e9fceab664b.png",
+    "date": "2024-09-17T00:22:40Z",
+    "game": "Star Wars Outlaws",
+    "type": "bronze",
+    "rarity": "42.1"
+  },
+  {
+    "id": "tNPWR30405_00-19",
+    "title": "Stay on target",
+    "summary": "Complete your first Intel chain",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR30405_00/9f95f95f-2b75-4a8a-8b6c-0c3b67db822d.png",
+    "date": "2024-09-15T21:46:03Z",
+    "game": "Star Wars Outlaws",
+    "type": "bronze",
+    "rarity": "49.8"
+  },
+  {
+    "id": "tNPWR21757_00-24",
+    "title": "''A fine addition to my collection''",
+    "summary": "Collect all Minikits in a single level",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR21757_00/199066a8-63ea-4a9a-9496-4ef3a380b4a3.png",
+    "date": "2024-09-11T23:38:25Z",
+    "game": "LEGO® Star Wars™: The Skywalker Saga",
+    "type": "bronze",
+    "rarity": "20.3"
+  },
+  {
+    "id": "tNPWR21757_00-26",
+    "title": "''Raw, untamed power''",
+    "summary": "Fully upgrade a character class",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR21757_00/dba1d870-b5c8-4ea1-abc0-c62c6dffcc83.png",
+    "date": "2024-09-10T19:53:39Z",
+    "game": "LEGO® Star Wars™: The Skywalker Saga",
+    "type": "bronze",
+    "rarity": "5.3"
+  },
+  {
+    "id": "tNPWR30405_00-33",
+    "title": "Like a bantha",
+    "summary": "Perform a perfect landing with the speeder",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR30405_00/815f5994-a0fd-45c2-b107-5931fa937b8d.png",
+    "date": "2024-09-08T13:53:35Z",
+    "game": "Star Wars Outlaws",
+    "type": "bronze",
+    "rarity": "63.0"
+  },
+  {
+    "id": "tNPWR30405_00-40",
+    "title": "Made it somehow",
+    "summary": "Acquire a blaster, a starship, and a speeder",
+    "image": "https://psnobj.prod.dl.playstation.net/psnobj/NPWR30405_00/bc7aa8b1-b55e-494d-a39e-495e4170ddc0.png",
+    "date": "2024-09-08T13:49:26Z",
+    "game": "Star Wars Outlaws",
+    "type": "bronze",
+    "rarity": "68.5"
+  }
+]

--- a/index.d.ts
+++ b/index.d.ts
@@ -294,8 +294,10 @@ interface Highlight {
   note: string;
   location: number;
   location_type: string;
-  highlighted_at: string;
-  url: string;
+  highlighted_at: string | null;
+  created_at: string;
+  readwise_url?: string;
+  url: string | null;
   color: string;
   updated: string;
   book_id: number;
@@ -303,7 +305,7 @@ interface Highlight {
     id: number;
     name: string;
   }[];
-  book: HighlightBook;
+  book?: HighlightBook;
 }
 
 interface HighlightBook {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "next": "^16.3.2",
         "octokit": "^4.1.3",
         "prismjs": "^1.30.0",
+        "psn-api": "^2.18.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-spring": "^10.0.4",
@@ -8664,6 +8665,16 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
       "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
       "dev": true
+    },
+    "node_modules/psn-api": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/psn-api/-/psn-api-2.18.1.tgz",
+      "integrity": "sha512-D0oVrJK+hVwJFARp2Io/auqJwjRx2t7x4Cke7mYNFbrOUQxSBONl0fHr4eVK5Bai89RNyaAsLPLFmgIw9pxzmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20",
+        "pnpm": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "next": "^16.3.2",
     "octokit": "^4.1.3",
     "prismjs": "^1.30.0",
+    "psn-api": "^2.18.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-spring": "^10.0.4",

--- a/pages/api/v1/activity.ts
+++ b/pages/api/v1/activity.ts
@@ -1,4 +1,5 @@
 import posts from "@data/posts";
+import trophies from "@data/trophies.json";
 import { parseISO } from "date-fns";
 import { NextApiRequest, NextApiResponse } from "next";
 import { setCacheControl } from "@lib/api";
@@ -425,7 +426,22 @@ export default async (
         }) as PostListItem,
     );
 
-    const allPosts = [...externalPosts, ...typedPosts];
+    // Trophies are refreshed on a schedule by scripts/update-trophies.ts, so
+    // they are read straight from the repo rather than fetched per request.
+    const trophyPosts = trophies.map(
+      (trophy) =>
+        ({
+          action: "Earned",
+          date: trophy.date,
+          id: trophy.id,
+          image: trophy.image,
+          summary: `${trophy.summary} — ${trophy.game}`,
+          title: trophy.title,
+          type: "TROPHY",
+        }) as PostListItem,
+    );
+
+    const allPosts = [...externalPosts, ...typedPosts, ...trophyPosts];
 
     // If none of the posts are of type "POST", add one that is.
     if (allPosts.every((post) => post.type !== "POST")) {

--- a/pages/api/v1/activity.ts
+++ b/pages/api/v1/activity.ts
@@ -53,7 +53,14 @@ const processEndpointData = async (
 ): Promise<PostListItem[]> => {
   try {
     const data = await fetchData(endpoint);
-    return formatFn(data).map((post) => formatPost({ ...post, type }));
+    const formatted = formatFn(data).map((post) => formatPost({ ...post, type }));
+    // A source that fetches fine but formats to nothing is the failure mode
+    // that hides — a shape change upstream drops the whole type with no error.
+    if (!formatted.length) {
+      const received = Array.isArray(data) ? data.length : "non-array";
+      console.warn(`${endpoint} yielded 0 ${type} posts from ${received} records`);
+    }
+    return formatted;
   } catch (error) {
     console.error(`Error processing data from ${endpoint}:`, error);
     return [];
@@ -257,16 +264,31 @@ const formatHighlightData = (
   highlights: Highlight[],
 ): Partial<PostListItem>[] =>
   highlights
-    .filter((highlight) => highlight.highlighted_at && highlight.book)
-    .map((highlight) => ({
-      action: "Highlighted",
-      date: highlight.highlighted_at,
-      id: `h${highlight.id}`,
-      title: highlight.text,
-      summary: `From ${highlight.book.title} by ${highlight.book.author}`,
-      image: highlight.book.cover_image_url,
-      url: highlight.book.source_url.replace(/=$/, ""),
-    }));
+    // Readwise leaves highlighted_at null on plenty of highlights, and book
+    // hydration can come back empty — neither should drop the highlight, since
+    // the text is the content. Requiring both silently emptied this source.
+    .filter((highlight) => highlight.text)
+    .map((highlight) => {
+      const book = highlight.book;
+      return {
+        action: "Highlighted",
+        date: highlight.highlighted_at ?? highlight.created_at ?? highlight.updated,
+        id: `h${highlight.id}`,
+        title: highlight.text,
+        summary: book ? `From ${book.title} by ${book.author}` : undefined,
+        image: book?.cover_image_url,
+        url:
+          book?.source_url?.replace(/=$/, "") ??
+          highlight.readwise_url ??
+          highlight.url ??
+          undefined,
+      };
+    })
+    .filter((post) => Boolean(post.date))
+    // Readwise syncs highlights in bulk, so without highlighted_at they all
+    // share one created_at and would otherwise swamp a day of the feed.
+    .sort((a, b) => +parseISO(b.date as string) - +parseISO(a.date as string))
+    .slice(0, 10);
 
 const formatMusicData = (music: Music[]): Partial<PostListItem>[] => {
   // Group by album ID, counting total streams and unique tracks per album

--- a/pages/api/v1/activity.ts
+++ b/pages/api/v1/activity.ts
@@ -435,7 +435,8 @@ export default async (
           date: trophy.date,
           id: trophy.id,
           image: trophy.image,
-          summary: `${trophy.summary} — ${trophy.game}`,
+          // Extra fields ride along in summary, as the chess cards do.
+          summary: `${trophy.summary} · Game: ${trophy.game} · Tier: ${trophy.type} · Rarity: ${trophy.rarity}`,
           title: trophy.title,
           type: "TROPHY",
         }) as PostListItem,

--- a/scripts/update-trophies.ts
+++ b/scripts/update-trophies.ts
@@ -1,0 +1,154 @@
+/**
+ * PSN trophy fetcher.
+ *
+ * Pulls recently earned trophies from Sony's own API (via psn-api) and writes
+ * them to data/trophies.json for the activity feed to import. Run on a schedule
+ * by .github/workflows/update-trophies.yml.
+ *
+ * Deliberately not a serverless route: collecting the feed takes dozens of API
+ * calls, well past the 8s budget activity.ts allows each endpoint.
+ *
+ * Usage: npx tsx scripts/update-trophies.ts
+ * Env: PSN_NPSSO — the npsso value from
+ *      https://ca.account.sony.com/api/v1/ssocookie while signed in to
+ *      playstation.com. Expires roughly every two months.
+ */
+
+import fs from "fs";
+import path from "path";
+
+import {
+  exchangeCodeForAccessToken,
+  exchangeNpssoForCode,
+  getTitleTrophies,
+  getUserTitles,
+  getUserTrophiesEarnedForTitle,
+  type AuthTokensResponse,
+} from "psn-api";
+
+const OUT_FILE = path.join(process.cwd(), "data/trophies.json");
+
+// How many trophies to keep, and how many recently-played titles to walk. The
+// feed only ever shows the newest handful, so there is no point paging through
+// a decade of back catalogue on every run.
+const MAX_TROPHIES = 40;
+const MAX_TITLES = 25;
+
+const MAX_ATTEMPTS = 5;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * PSN rate-limits fairly aggressively when walking many titles, so give any
+ * failure a few chances before letting the run fail.
+ */
+async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  let lastError: unknown;
+
+  for (let i = 1; i <= MAX_ATTEMPTS; i++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (i === MAX_ATTEMPTS) break;
+      const backoff = 2 ** (i - 1) * 1000 + Math.floor(Math.random() * 500);
+      console.log(`${label} attempt ${i}/${MAX_ATTEMPTS} failed, retrying in ${backoff}ms`);
+      await sleep(backoff);
+    }
+  }
+
+  throw new Error(`${label} failed after ${MAX_ATTEMPTS} attempts: ${String(lastError)}`);
+}
+
+interface Trophy {
+  id: string;
+  title: string;
+  summary: string;
+  image: string;
+  date: string;
+  game: string;
+  type: string;
+  rarity: string;
+}
+
+async function main() {
+  const npsso = process.env.PSN_NPSSO;
+  if (!npsso) throw new Error("PSN_NPSSO not set");
+
+  const auth: AuthTokensResponse = await withRetry("PSN auth", async () =>
+    exchangeCodeForAccessToken(await exchangeNpssoForCode(npsso)),
+  );
+  console.log("Authenticated with PSN.");
+
+  const { trophyTitles } = await withRetry("getUserTitles", () =>
+    getUserTitles(auth, "me", { limit: MAX_TITLES }),
+  );
+
+  // Titles are returned newest-played first. Skip the ones where nothing has
+  // been earned — started-but-untouched games are common and cost two calls each.
+  const played = trophyTitles.filter((title) => {
+    const { bronze, silver, gold, platinum } = title.earnedTrophies;
+    return bronze + silver + gold + platinum > 0;
+  });
+  console.log(`${played.length} of ${trophyTitles.length} recent titles have earned trophies.`);
+
+  const trophies: Trophy[] = [];
+
+  for (const title of played) {
+    // PS5 titles use the default service; older ones must ask for "trophy".
+    const options = title.trophyTitlePlatform.includes("PS5")
+      ? {}
+      : { npServiceName: "trophy" as const };
+
+    try {
+      const [earned, defs] = await Promise.all([
+        withRetry(`earned:${title.trophyTitleName}`, () =>
+          getUserTrophiesEarnedForTitle(auth, "me", title.npCommunicationId, "all", options),
+        ),
+        withRetry(`defs:${title.trophyTitleName}`, () =>
+          getTitleTrophies(auth, title.npCommunicationId, "all", options),
+        ),
+      ]);
+
+      const byId = new Map(defs.trophies.map((d) => [d.trophyId, d]));
+
+      for (const t of earned.trophies) {
+        const def = byId.get(t.trophyId);
+        if (!t.earned || !t.earnedDateTime || !def?.trophyName) continue;
+
+        trophies.push({
+          id: `t${title.npCommunicationId}-${t.trophyId}`,
+          title: def.trophyName,
+          summary: def.trophyDetail ?? "",
+          image: def.trophyIconUrl ?? "",
+          date: t.earnedDateTime,
+          game: title.trophyTitleName,
+          type: def.trophyType ?? "",
+          rarity: t.trophyEarnedRate ?? "",
+        });
+      }
+    } catch (error) {
+      // One bad title shouldn't lose the whole feed.
+      console.error(`Skipping ${title.trophyTitleName}: ${String(error)}`);
+    }
+  }
+
+  trophies.sort((a, b) => Date.parse(b.date) - Date.parse(a.date));
+  const recent = trophies.slice(0, MAX_TROPHIES);
+
+  const previous = fs.existsSync(OUT_FILE) ? fs.readFileSync(OUT_FILE, "utf-8") : "";
+  const next = `${JSON.stringify(recent, null, 2)}\n`;
+
+  if (previous === next) {
+    console.log(`No changes. ${recent.length} trophies.`);
+    return;
+  }
+
+  fs.writeFileSync(OUT_FILE, next);
+  console.log(`Wrote ${recent.length} trophies, newest ${recent[0]?.date ?? "—"}.`);
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Replaces the abandoned psnprofiles scraper with Sony's own API via `psn-api` (232KB, zero runtime deps, MIT) instead of ~170MB of headless Chromium.

A scheduled workflow writes `data/trophies.json`, which `activity.ts` imports directly — the same pattern as themes and posts. No browser, no runtime auth, no scraping, and it can't hit the 8s per-endpoint budget because it does no work at request time. Runs 30 min after Update Themes so the two never race to push.

The `TROPHY` type, `TrophyPost` component and auto-tooter case already existed; only the data source was missing.

Verified against the live account: 40 trophies fetched, typecheck and build clean, and `/api/v1/activity` returns 27 TROPHY items locally.

Needs the `PSN_NPSSO` repo secret (already set). It expires roughly every two months and will need re-pasting from https://ca.account.sony.com/api/v1/ssocookie.