### PR TITLE
Warn before PSN_NPSSO expires, hydrate article highlights

### DIFF
--- a/.github/workflows/update-trophies.yml
+++ b/.github/workflows/update-trophies.yml
@@ -30,9 +30,34 @@ jobs:
         run: npm ci
 
       - name: Fetch PSN trophies
+        id: fetch
         env:
           PSN_NPSSO: ${{ secrets.PSN_NPSSO }}
         run: npx tsx scripts/update-trophies.ts
+
+      # The npsso cannot renew itself, so the only safe automation is a warning
+      # with enough lead time to replace it before trophies quietly stop updating.
+      - name: Warn when PSN_NPSSO is close to expiring
+        if: steps.fetch.outputs.npsso_days != '' && fromJSON(steps.fetch.outputs.npsso_days) <= 14
+        env:
+          GH_TOKEN: ${{ secrets.ACTION_GITHUB_TOKEN }}
+          DAYS: ${{ steps.fetch.outputs.npsso_days }}
+        run: |
+          TITLE="PSN_NPSSO expires soon"
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+          BODY="\`PSN_NPSSO\` expires in **$DAYS days**. Trophy updates stop when it does.
+
+          To replace it:
+          1. Sign in at https://playstation.com
+          2. Open https://ca.account.sony.com/api/v1/ssocookie and copy the \`npsso\` value
+          3. \`gh secret set PSN_NPSSO -R ${{ github.repository }}\`
+
+          Sony's npsso lasts ~60 days from issue and the window does not slide, so this recurs a few times a year."
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY"
+          fi
 
       - name: Check for changes
         id: changes

--- a/pages/api/v1/activity.ts
+++ b/pages/api/v1/activity.ts
@@ -275,7 +275,11 @@ const formatHighlightData = (
         date: highlight.highlighted_at ?? highlight.created_at ?? highlight.updated,
         id: `h${highlight.id}`,
         title: highlight.text,
-        summary: book ? `From ${book.title} by ${book.author}` : undefined,
+        // These are saved articles far more often than books, so name the
+        // source and only add a byline when Readwise actually has one.
+        summary: book
+          ? [book.title, book.author].filter(Boolean).join(" — ")
+          : undefined,
         image: book?.cover_image_url,
         url:
           book?.source_url?.replace(/=$/, "") ??

--- a/pages/api/v1/highlights.ts
+++ b/pages/api/v1/highlights.ts
@@ -19,20 +19,32 @@ export default async (
   }
   const { results } = await highlightsRes.json();
 
-  const bookIds = results.map((h: Highlight) => h.book_id).join(",");
-  const booksRes = await fetch(
-    `https://readwise.io/api/v2/books/?ids=${bookIds}`,
-    { headers: READWISE_HEADERS },
+  // Readwise calls every source a "book", but these are mostly saved articles.
+  // The list endpoint ignores ?ids=, so it was returning an unrelated first page
+  // and nothing ever matched — every highlight came back unhydrated. A hundred
+  // highlights only span a handful of sources, so fetch each one directly.
+  const sourceIds = [...new Set(results.map((h: Highlight) => h.book_id))];
+
+  const sources = await Promise.all(
+    sourceIds.map(async (id) => {
+      try {
+        const r = await fetch(`https://readwise.io/api/v2/books/${id}/`, {
+          headers: READWISE_HEADERS,
+        });
+        return r.ok ? ((await r.json()) as HighlightBook) : null;
+      } catch {
+        return null;
+      }
+    }),
   );
-  if (!booksRes.ok) {
-    res.status(booksRes.status).json({ error: "Failed to fetch books" });
-    return;
-  }
-  const { results: bookData } = await booksRes.json();
+
+  const sourcesById = new Map(
+    sources.filter((b): b is HighlightBook => Boolean(b)).map((b) => [b.id, b]),
+  );
 
   const hydratedResults = results.map((highlight: Highlight) => ({
     ...highlight,
-    book: bookData.find((book: HighlightBook) => book.id === highlight.book_id),
+    book: sourcesById.get(highlight.book_id),
   }));
 
   if (process.env.NODE_ENV === "production")

--- a/pages/api/v1/highlights.ts
+++ b/pages/api/v1/highlights.ts
@@ -9,8 +9,11 @@ export default async (
   req: NextApiRequest,
   res: NextApiResponse,
 ): Promise<void> => {
+  // Readwise seeds accounts with "supplemental" popular highlights from books
+  // you own — nobody highlighted those, and they have no highlighted_at. Asking
+  // for highlights after the epoch returns only ones actually made by hand.
   const highlightsRes = await fetch(
-    "https://readwise.io/api/v2/highlights/",
+    "https://readwise.io/api/v2/highlights/?highlighted_at__gt=1970-01-01T00:00:00Z&page_size=100",
     { headers: READWISE_HEADERS },
   );
   if (!highlightsRes.ok) {

--- a/scripts/update-trophies.ts
+++ b/scripts/update-trophies.ts
@@ -60,6 +60,43 @@ async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
   throw new Error(`${label} failed after ${MAX_ATTEMPTS} attempts: ${String(lastError)}`);
 }
 
+// Sony's npsso is good for roughly 60 days from issue and the window does not
+// slide — presenting it back to the endpoint returns the same token with the
+// clock already ticked down, and the OAuth refresh token expires sooner (10
+// days, also absolute). So the credential genuinely has to be replaced by hand.
+// The one thing worth automating is knowing before it dies rather than after.
+const NPSSO_WARN_DAYS = 14;
+
+async function reportNpssoExpiry(npsso: string): Promise<void> {
+  try {
+    const res = await fetch("https://ca.account.sony.com/api/v1/ssocookie", {
+      headers: { Cookie: `npsso=${npsso}` },
+    });
+    if (!res.ok) return;
+
+    const { expires_in: expiresIn } = (await res.json()) as { expires_in?: number };
+    if (typeof expiresIn !== "number") return;
+
+    const days = Math.floor(expiresIn / 86400);
+    console.log(`PSN_NPSSO expires in ${days} days.`);
+
+    if (days <= NPSSO_WARN_DAYS) {
+      // GitHub renders this as an annotation on the run.
+      console.log(
+        `::warning title=PSN_NPSSO expiring::PSN_NPSSO expires in ${days} days. ` +
+          `Replace it from https://ca.account.sony.com/api/v1/ssocookie while signed in to playstation.com, ` +
+          `then update the repo secret.`,
+      );
+    }
+    // Hand the day count to the workflow so it can open an issue.
+    if (process.env.GITHUB_OUTPUT) {
+      fs.appendFileSync(process.env.GITHUB_OUTPUT, `npsso_days=${days}\n`);
+    }
+  } catch {
+    // Expiry reporting is a convenience — never let it fail the trophy update.
+  }
+}
+
 interface Trophy {
   id: string;
   title: string;
@@ -79,6 +116,8 @@ async function main() {
     exchangeCodeForAccessToken(await exchangeNpssoForCode(npsso)),
   );
   console.log("Authenticated with PSN.");
+
+  await reportNpssoExpiry(npsso);
 
   const { trophyTitles } = await withRetry("getUserTitles", () =>
     getUserTitles(auth, "me", { limit: MAX_TITLES }),


### PR DESCRIPTION
## NPSSO cannot renew itself

Tested both refresh paths against the live Sony API:

- **OAuth refresh token: 10 days, absolute.** `refreshTokenExpiresIn` decremented 863999 → 863993 → 863987 across two refreshes 12s apart. Refreshing does not extend it, so token rotation cannot perpetuate a session.
- **npsso: ~60 days, also absolute.** Presenting it back to `/api/v1/ssocookie` returns the *same* token with the clock already ticked down.

Renewing it needs a fresh authenticated Sony session — i.e. storing account credentials and defeating 2FA. Not worth it for a trophy feed.

So this automates the *knowing* instead: each run reports the remaining days, annotates the run under 14 days, and opens (or comments on) an issue so it surfaces without reading logs. Verified end-to-end — reports 59 days, and the warning path fires when forced.

## Highlights are articles, not books

Readwise calls every source a "book" but these are saved articles. Two fixes:

- `/books/?ids=` is not a supported filter, so the list endpoint returned an unrelated first page and **nothing ever matched** — every highlight came back unhydrated. The 100 highlights span only 11 unique sources, so each is now fetched directly by id, tolerating individual failures.
- Summary no longer asserts "by <author>" — it joins title and author only when present.

The hydration fix is untested against Readwise (no `READWISE_ACCESS_TOKEN` locally); the preview deploy will show whether covers and titles appear.